### PR TITLE
Fix thumbnails not showing on < API 21

### DIFF
--- a/app/src/main/java/com/perflyst/twire/adapters/MainActivityAdapter.java
+++ b/app/src/main/java/com/perflyst/twire/adapters/MainActivityAdapter.java
@@ -151,7 +151,11 @@ public abstract class MainActivityAdapter<E extends Comparable<E> & MainElement,
                             .placeholder(ContextCompat.getDrawable(context, element.getPlaceHolder(getContext())));
 
             if (isBelowLollipop) {
-                creator = creator.transform(new RoundedTopTransformation(context.getResources().getDimension(getCornerRadiusRessource())));
+                /* On platforms before Lollipop the CardView that holds the preview image does not
+                 * clip its children that intersect with rounded corners. Round the image corners so
+                 * the rounded corners still appear. */
+                creator = creator.transform(new RoundedTopTransformation(
+                        context.getResources().getDimension(getCornerRadiusRessource())));
             }
 
             if (mTargets.get(viewHolder.getTargetsKey()) != null) {

--- a/app/src/main/java/com/perflyst/twire/misc/RoundedTopTransformation.java
+++ b/app/src/main/java/com/perflyst/twire/misc/RoundedTopTransformation.java
@@ -51,12 +51,15 @@ public class RoundedTopTransformation extends BitmapTransformation {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof RoundedTopTransformation;
+        if (o instanceof RoundedTopTransformation) {
+            return cornerRadius == ((RoundedTopTransformation) o).cornerRadius;
+        }
+        return false;
     }
 
     @Override
     public int hashCode() {
-        return ID.hashCode();
+        return (int) cornerRadius * 31 + ID.hashCode();
     }
 
     @Override

--- a/app/src/main/java/com/perflyst/twire/misc/RoundedTopTransformation.java
+++ b/app/src/main/java/com/perflyst/twire/misc/RoundedTopTransformation.java
@@ -31,7 +31,8 @@ public class RoundedTopTransformation extends BitmapTransformation {
     }
 
     @Override
-    protected Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
+    protected Bitmap transform(
+            @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
         int w = toTransform.getWidth();
         int h = toTransform.getHeight();
         Bitmap bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
@@ -45,7 +46,6 @@ public class RoundedTopTransformation extends BitmapTransformation {
         RectF rec = new RectF(0, 0, w, h - (h / 3));
         c.drawRect(new RectF(0, (h / 3), w, h), paint);
         c.drawRoundRect(rec, cornerRadius, cornerRadius, paint);
-        toTransform.recycle();
         return bmp;
     }
 

--- a/app/src/main/java/com/perflyst/twire/service/AnimationService.java
+++ b/app/src/main/java/com/perflyst/twire/service/AnimationService.java
@@ -1,12 +1,6 @@
 package com.perflyst.twire.service;
 
 import android.app.Activity;
-import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.Canvas;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.TransitionDrawable;
 import android.os.Handler;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
@@ -14,7 +8,6 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.AnimationSet;
 import android.view.animation.TranslateAnimation;
-import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.appcompat.widget.Toolbar;
@@ -272,40 +265,6 @@ public class AnimationService {
             if (aCard != null)
                 aCard.startAnimation(animationSet);
         }, delay);
-    }
-
-    /**
-     * Makes sure an ImageView is valid for creating a TransitionDrawable with @setPicassoShowImageAnimationTwo
-     *
-     * @param imageView
-     * @return
-     */
-    private static boolean isImageViewValidForTransition(ImageView imageView) {
-        return imageView.getDrawable() != null && !(imageView.getDrawable() instanceof TransitionDrawable);
-    }
-
-    public static void setPicassoShowImageAnimationTwo(final ImageView aImageView, final Bitmap toImage, Context context) {
-        if (toImage == null) {
-            return;
-        }
-
-        if (isImageViewValidForTransition(aImageView)) {
-            Bitmap newBitmap = Bitmap.createBitmap(toImage.getWidth(), toImage.getHeight(), toImage.getConfig()); //ToDo: Out of memory exception here
-            Canvas canvas = new Canvas(newBitmap);
-            canvas.drawColor(Service.getColorAttribute(R.attr.cardBackgroundColor, R.color.white, context));
-            canvas.drawBitmap(toImage, 0, 0, null);
-
-            // create the transition layers
-            Drawable[] layers = new Drawable[2];
-            layers[0] = aImageView.getDrawable();
-            layers[1] = new BitmapDrawable(context.getResources(), newBitmap);
-
-            TransitionDrawable transitionDrawable = new TransitionDrawable(layers);
-            aImageView.setImageDrawable(transitionDrawable);
-            transitionDrawable.startTransition(300);
-        } else {
-            aImageView.setImageBitmap(toImage);
-        }
     }
 
     /**


### PR DESCRIPTION
Preview images for streams, VODs, games, etc. fail to load on devices running an Android version before Lollipop. This is due to the implementation of a custom transformation for the Glide library.

Glide's `BitmapTransformation` instances should not recycle `toTransform` in transform method or it will cause a `java.lang.IllegalStateException: Cannot pool recycled bitmap.`, and prevent thumbnails from appearing.

See [`BitmapTransformation.transform`](https://bumptech.github.io/glide/javadocs/440/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.html#transform-com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool-android.graphics.Bitmap-int-int-) for more info:
> The provided Bitmap, toTransform, should not be recycled or returned to the pool. Glide will automatically recycle and/or reuse toTransform if the transformation returns a different Bitmap.

### Known issues
- A very small part of a thumbnail's top corners can be white sometimes. This white is the area outside of the rounded rectangle that was painted with the bitmap. Pulling to refresh causes these white corners to not appear. The white corners are not large enough to interfere with seeing the thumbnail, and the advantages of getting the thumbnail to appear at all outweigh this minor imperfection.