### PR TITLE
Fix emote position bug

### DIFF
--- a/app/src/main/java/com/perflyst/twire/tasks/ConstructChatMessageTask.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/ConstructChatMessageTask.java
@@ -88,7 +88,7 @@ public class ConstructChatMessageTask extends AsyncTask<Void, Void, ChatMessage>
 
                         wordOccurenc.put(word, wordIndex + word.length() - 1);
 
-                        result.add(new ChatEmote(emote, new int[] { fromIndex }));
+                        result.add(new ChatEmote(emote, new int[] { wordIndex }));
                     }
                 }
             }


### PR DESCRIPTION
## Problem

Relatively minor, but when you send a message with an emote, the emote shows up at the beginning of the message _only for you_.
See screenshot (Message says `Nice :PogChamp:`)
<img width="126" alt="Screen Shot 2020-08-18 at 6 27 09 PM" src="https://user-images.githubusercontent.com/34136040/90571871-ae075100-e180-11ea-83c8-8d7fda2d463e.png">


## Solution

Swap `fromIndex` with `wordIndex` when construction a message

## Testing

- Send a message with an emote at the end
  - Emote is in correct position
- Revert this change
  - Emote at beginning of message