### PR TITLE
Highlight Message When Logged-In User Is Mentioned

### DIFF
--- a/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
+++ b/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
@@ -493,6 +493,12 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
             //Pattern.compile(Pattern.quote(userDisplayName), Pattern.CASE_INSENSITIVE).matcher(message).find();
 
             ChatMessage chatMessage = new ChatMessage(message, displayName, color, getBadges(badges), emotes, false);
+
+            if(message.contains("@" + getUserDisplayName())) {
+                Log.d(LOG_TAG, "Highlighting message with mention: " + message);
+                chatMessage.setHighlight(true);
+            }
+
             publishProgress(new ProgressUpdate(ProgressUpdate.UpdateType.ON_MESSAGE, chatMessage));
         } else {
             Log.e(LOG_TAG, "Failed to find message pattern in: \n" + line);


### PR DESCRIPTION
Implements feature requested by @Nextross in #129.

### Additional Context
Highlighting is done for message received that contains an "@" mention of the currently logged in Twitch user.

### Screenshot:
![image](https://user-images.githubusercontent.com/13066221/94933057-7dd50100-04e7-11eb-83b6-88fae2356134.png)
