### PR TITLE
Migrate activities to ViewPager2

### DIFF
--- a/app/src/main/java/com/perflyst/twire/activities/SearchActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/SearchActivity.java
@@ -10,13 +10,15 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentPagerAdapter;
-import androidx.viewpager.widget.ViewPager;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
 import com.perflyst.twire.R;
 import com.perflyst.twire.activities.main.LazyFetchingActivity;
 import com.perflyst.twire.adapters.ChannelsAdapter;
@@ -50,8 +52,12 @@ import butterknife.ButterKnife;
 
 
 public class SearchActivity extends ThemeActivity {
+    private static final int POSITION_STREAMS = 0;
+    private static final int POSITION_CHANNELS = 1;
+    private static final int POSITION_GAMES = 2;
+    private static final int TOTAL_COUNT = 3;
     @BindView(R.id.container)
-    protected ViewPager mViewPager;
+    protected ViewPager2 mViewPager;
     @BindView(R.id.ic_back_arrow)
     protected ImageView mBackIcon;
     @BindView(R.id.edit_text_search)
@@ -100,14 +106,26 @@ public class SearchActivity extends ThemeActivity {
     private void setUpTabs() {
         // Create the adapter that will return a fragment for each of the three
         // primary sections of the activity.
-        SectionsPagerAdapter mSectionsPagerAdapter = new SectionsPagerAdapter(getSupportFragmentManager());
+        SectionsPagerAdapter mSectionsPagerAdapter = new SectionsPagerAdapter(this);
 
-        // Set up the ViewPager with the sections adapter.
+        // Set up the ViewPager2 with the sections adapter.
         mViewPager.setAdapter(mSectionsPagerAdapter);
 
         TabLayout tabLayout = findViewById(R.id.tabs);
-        assert tabLayout != null;
-        tabLayout.setupWithViewPager(mViewPager);
+        new TabLayoutMediator(tabLayout, mViewPager, (tab, position) -> {
+            switch (position) {
+                default: // Deliberate fall-through to stream tab
+                case POSITION_STREAMS:
+                    tab.setText(R.string.streams_tab);
+                    break;
+                case POSITION_CHANNELS:
+                    tab.setText(R.string.streamers_tab);
+                    break;
+                case POSITION_GAMES:
+                    tab.setText(R.string.games_tab);
+                    break;
+            }
+        }).attach();
     }
 
     public String getQuery() {
@@ -400,49 +418,32 @@ public class SearchActivity extends ThemeActivity {
         public abstract MainActivityAdapter<E, ?> constructAdapter();
     }
 
-    private class SectionsPagerAdapter extends FragmentPagerAdapter {
-        private final int POSITION_STREAMS = 0;
-        private final int POSITION_CHANNELS = 1;
-        private final int POSITION_GAMES = 2;
+    private class SectionsPagerAdapter extends FragmentStateAdapter {
 
-
-        SectionsPagerAdapter(FragmentManager fm) {
-            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
+        SectionsPagerAdapter(FragmentActivity fa) {
+            super(fa);
             mStreamsFragment = SearchStreamsFragment.newInstance();
             mChannelsFragment = SearchChannelsFragment.newInstance();
             mGamesFragment = SearchGamesFragment.newInstance();
         }
 
+        @NonNull
         @Override
-        public Fragment getItem(int position) {
+        public Fragment createFragment(int position) {
             switch (position) {
+                default: // Deliberate fall-through to stream tab
                 case POSITION_STREAMS:
                     return mStreamsFragment;
                 case POSITION_CHANNELS:
                     return mChannelsFragment;
                 case POSITION_GAMES:
                     return mGamesFragment;
-                default:
-                    return SearchStreamsFragment.newInstance();
             }
         }
 
         @Override
-        public int getCount() {
-            return 3;
-        }
-
-        @Override
-        public CharSequence getPageTitle(int position) {
-            switch (position) {
-                case POSITION_STREAMS:
-                    return getResources().getString(R.string.streams_tab);
-                case POSITION_CHANNELS:
-                    return getResources().getString(R.string.streamers_tab);
-                case POSITION_GAMES:
-                    return getResources().getString(R.string.games_tab);
-            }
-            return null;
+        public int getItemCount() {
+            return TOTAL_COUNT;
         }
     }
 }

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -92,7 +92,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_streamer_info.xml
+++ b/app/src/main/res/layout/activity_streamer_info.xml
@@ -145,7 +145,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Yes, the holy viewpager2 migration. But first, some problems.

Before we begin, the migrated channel and search activities work perfectly fine. Those have no issues.

However, the chat fragment has two bugs that need to be fixed. Both bugs have to do with the emotes.

The first came with the migration (likely due to a coding mistake of some sort). The second one has already existed but became much more obvious after the migration due to a behavior change that probably comes with viewpager2. I don't really know how to fix either of these bugs.

Bug 1 (new bug, and you will see it plain as day): OH GOD THE UNICODE EMOJI TAB IS MISSING. Well, yes but no. Swipe to it (or tap on where the icon would be), and the tab icon will load. I can't seem to find any reason why the other tabs color just fine, yet the unicode emoji tab won't. If you turn on the dark modes, you will find that the unicode emoji tab icon is plain white while the others are correctly tinted. Apparently this specific tab just doesn't tint correctly until you swipe to or tap on it, and then it's fine afterward (unless you exit the stream and go back in again, then you have to do it over again).

(Funny thing about bug 1: it was actually much worse, with none showing until swiping or tapping on them, but I managed to fix that by [moving the for loop into the TabLayoutMediator](https://github.com/twireapp/Twire/pull/152/commits/311feb439c3130e22970524958d47f28798b241a#diff-5a001d067523d1be3715aa4d0bbaf4d6c70945846ca33f145552f3475571ec70R621).)

Bug 2 (existing bug): First, test your existing 2.9.0 stable F-Droid release version, and go to a random current stream. You should be able to reproduce [this behavior](https://streamable.com/yv6o58) (watch the whole thing). Now test the APK I've attached below and try the same thing. You will quickly see that the already unwanted behavior has changed for the worse: now you won't be able to scroll to the bottom because it jumps. One should be able to scroll completely up and down without any sort of stopping before the end of the list.


Here's an APK so you can see this migration in action for yourself (remember to check out the channel and search activity tabs, as those have been migrated to viewpager2): [app-debug.zip](https://github.com/twireapp/Twire/files/5470144/app-debug.zip)


There are several roads to take:
1.) This can be merged just as-is, and bug fixes can be made in following commits.
2.) I always allow edits by maintainers, so bug fixes can be committed to this PR.

Either way, these bugs should probably be fixed before the next release.