### PR TITLE
Library updating

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation "com.github.afollestad.material-dialogs:commons:0.8.6.2@aar"
 
     //https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md
-    def exoPlayer = "2.12.0"
+    def exoPlayer = "2.12.1"
     implementation "com.google.android.exoplayer:exoplayer-core:$exoPlayer"
     implementation "com.google.android.exoplayer:exoplayer-hls:$exoPlayer"
     implementation "com.google.android.exoplayer:exoplayer-ui:$exoPlayer"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.browser:browser:1.2.0"
+    implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.cardview:cardview:1.0.0"
     // Pinned to 1.1.3 as 2.0.0 seems to break the stream fragment.
     // Might be a bug with 2.0.0: https://issuetracker.google.com/issues/166486001
@@ -66,9 +66,6 @@ dependencies {
 
     //https://github.com/KasualBusiness/MaterialNumberPicker/releases
     implementation "biz.kasual:materialnumberpicker:1.2.1"
-
-    //https://github.com/google/guava/releases
-    implementation "com.google.guava:guava:29.0-jre"
 
     //https://github.com/google/gson/blob/master/CHANGELOG.md
     implementation "com.google.code.gson:gson:2.8.6"

--- a/app/src/main/java/com/perflyst/twire/activities/stream/StreamActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/stream/StreamActivity.java
@@ -25,6 +25,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
@@ -38,8 +39,6 @@ import com.perflyst.twire.service.Settings;
 
 import java.util.List;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
@@ -346,7 +345,7 @@ public abstract class StreamActivity extends ThemeActivity implements SensorEven
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    public void navToLauncherTask(@Nonnull Context appContext) {
+    public void navToLauncherTask(@NonNull Context appContext) {
         ActivityManager activityManager = ContextCompat.getSystemService(appContext, ActivityManager.class);
         // iterate app tasks available and navigate to launcher task (browse task)
         if (activityManager != null) {

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -1285,7 +1285,7 @@ public class StreamFragment extends Fragment implements Player.EventListener, Pl
         if (isAudioOnlyModeEnabled()) {
             Log.d(LOG_TAG, "Pausing audio");
         } else if (player != null) {
-            player.setPlayWhenReady(false);
+            player.pause();
         }
         releaseScreenOn();
     }
@@ -1302,7 +1302,7 @@ public class StreamFragment extends Fragment implements Player.EventListener, Pl
                 player.seekToDefaultPosition(); // Go forward to live
             }
 
-            player.setPlayWhenReady(true);
+            player.play();
         }
 
         keepScreenOn();
@@ -1452,10 +1452,7 @@ public class StreamFragment extends Fragment implements Player.EventListener, Pl
         properties.set("Origin", "https://player.twitch.tv");
 
         MediaSource mediaSource = new HlsMediaSource.Factory(dataSourceFactory)
-                .createMediaSource(
-                        new MediaItem.Builder()
-                                .setUri(Uri.parse(url))
-                                .build());
+                .createMediaSource(MediaItem.fromUri(Uri.parse(url)));
         currentMediaSource = mediaSource;
         player.setMediaSource(mediaSource);
         player.prepare();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Here's a quick little thing before the next bugfix release.

- Update gradle wrapper to 6.7.1 using git bash
- Update AndroidX Browser 1.2.0 -> 1.3.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/browser))
- Update ExoPlayer 2.12.0 -> 2.12.1 ([changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md))
- Remove unused Guava library
- Clean up a few ExoPlayer things

I need some help updating ExoPlayer to 2.12.2; I'm not exactly sure what to do with the PlaybackPreparer deprecations. I guess that can be done later though.