### PR TITLE
Add auto rotation to setup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,12 +103,12 @@
         <activity
             android:name=".activities.setup.WelcomeActivity"
             android:label="@string/title_activity_welcome"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="sensor" />
         <activity
             android:name=".activities.setup.LoginActivity"
             android:label="@string/title_activity_login"
             android:parentActivityName=".activities.setup.WelcomeActivity"
-            android:screenOrientation="portrait">
+            android:screenOrientation="sensor">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.setup.WelcomeActivity" />
@@ -116,7 +116,7 @@
         <activity
             android:name=".activities.setup.ConfirmSetupActivity"
             android:label="@string/title_activity_welcome"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="sensor" />
         <activity
             android:name=".activities.StartUpActivity"
             android:exported="true"


### PR DESCRIPTION
This is fixing [#206 ](https://github.com/twireapp/Twire/issues/206).

The changes have been tested on:
- Android Virtual Pixel XL, Android 11.0
- Xiaomi Redmi Note 7, Android 11.0

Behavior:
Twire 2.9.3: The Setup and Login Screen are Stuck in Portrait Mode.
Twire Debug: The Setup and Login screen is auto rotating.

Preview (Video):
[![Add auto rotation to setup](https://img.youtube.com/vi/dOCVCl5_BF0/0.jpg)](https://www.youtube.com/watch?v=dOCVCl5_BF0)