### PR TITLE
Fix Followed Streamers not being committed to Database

### DIFF
--- a/app/src/main/java/com/perflyst/twire/tasks/AddFollowsToDB.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/AddFollowsToDB.java
@@ -77,6 +77,8 @@ public class AddFollowsToDB extends AsyncTask<Object, Void, ArrayList<ChannelInf
                 values.put(SubscriptionsDbHelper.COLUMN_PROFILE_BANNER_URL, subToAdd.getProfileBannerURL().toString());
 
 
+            db.insert(SubscriptionsDbHelper.TABLE_NAME, null, values);
+
             // we return the rowId so we can return the row we inserted to a cursor
             /*
             long rowId = db.insert(SubscriptionsDbHelper.TABLE_NAME, null, values);


### PR DESCRIPTION
# Issue
When switching to the Followed Streamers Tab I always get an error with "Oops Twitch Servers didn`t respond in time" (See Picture Below).  When I looked into the Database that is getting created then it is empty.

Could be related to https://github.com/twireapp/Twire/issues/101

# Fix
When adding the following line
`
db.insert(SubscriptionsDbHelper.TABLE_NAME, null, values);
`
then the Database gets filled and at the next launch, the followed Streamers load without an error.

## Pictures
![](https://i.imgur.com/RLT6nL7.png)

## Videos

### Not Fixed
[![](https://img.youtube.com/vi/aM2wCAo4Vpo/0.jpg)](https://www.youtube.com/watch?v=aM2wCAo4Vpo)

### Fixed
[![](https://img.youtube.com/vi/UJRgidv5ajs/0.jpg)](https://www.youtube.com/watch?v=UJRgidv5ajs)