### PR TITLE
Library updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "com.android.application"
 android {
     compileSdkVersion 29
     buildToolsVersion "30.0.3"
-    ndkVersion "22.0.7026061"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         applicationId "com.perflyst.twire"
@@ -42,6 +42,7 @@ android {
 }
 
 dependencies {
+    //AndroidX
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.cardview:cardview:1.0.0"
@@ -49,9 +50,11 @@ dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.palette:palette:1.0.0"
     implementation "androidx.preference:preference:1.1.1"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.transition:transition:1.4.0"
-    implementation "com.google.android.material:material:1.2.1"
+    implementation "androidx.recyclerview:recyclerview:1.2.0"
+    implementation "androidx.transition:transition:1.4.1"
+    //  https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.2.0-alpha02
+    implementation "androidx.viewpager2:viewpager2:1.1.0-alpha01"
+    implementation "com.google.android.material:material:1.3.0"
 
     //https://github.com/bumptech/glide/releases
     def glideVersion = "4.12.0"
@@ -72,7 +75,7 @@ dependencies {
     implementation "biz.kasual:materialnumberpicker:1.2.1"
 
     //https://github.com/google/gson/blob/master/CHANGELOG.md
-    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "com.google.code.gson:gson:2.8.7"
 
     //https://github.com/JakeWharton/butterknife/blob/master/CHANGELOG.md
     implementation "com.jakewharton:butterknife:10.2.3"
@@ -93,7 +96,7 @@ dependencies {
     implementation "com.google.android.exoplayer:extension-mediasession:$exoPlayer"
 
     //https://github.com/google/conscrypt/releases
-    implementation "org.conscrypt:conscrypt-android:2.5.1"
+    implementation "org.conscrypt:conscrypt-android:2.5.2"
 
     //https://github.com/square/okhttp
     implementation "com.squareup.okhttp3:okhttp:3.12.13"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,9 +70,8 @@ dependencies {
     //https://github.com/Perflyst/SRJNeeds
     implementation "com.github.perflyst:srjneeds:85306c8"
 
-    //https://github.com/KasualBusiness/MaterialNumberPicker/releases
-    // TODO URGENT: Migrate to https://github.com/StephenVinouze/MaterialNumberPicker
-    implementation "biz.kasual:materialnumberpicker:1.2.1"
+    //https://github.com/StephenVinouze/MaterialNumberPicker/releases
+    implementation "com.github.StephenVinouze:MaterialNumberPicker:1.1.0"
 
     //https://github.com/google/gson/blob/master/CHANGELOG.md
     implementation "com.google.code.gson:gson:2.8.7"

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -62,6 +62,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.balysv.materialripple.MaterialRippleLayout;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.signature.ObjectKey;
+import com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
@@ -104,8 +105,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import biz.kasual.materialnumberpicker.MaterialNumberPicker;
 
 public class StreamFragment extends Fragment implements Player.Listener {
     private static int totalVerticalInset;

--- a/app/src/main/java/com/perflyst/twire/model/SleepTimer.java
+++ b/app/src/main/java/com/perflyst/twire/model/SleepTimer.java
@@ -6,11 +6,10 @@ import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 
+import com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker;
 import com.perflyst.twire.R;
 import com.perflyst.twire.service.DialogService;
 import com.perflyst.twire.service.Settings;
-
-import biz.kasual.materialnumberpicker.MaterialNumberPicker;
 
 /**
  * Created by Sebastian Rask Jepsen on 22/07/16.

--- a/app/src/main/java/com/perflyst/twire/service/DialogService.java
+++ b/app/src/main/java/com/perflyst/twire/service/DialogService.java
@@ -10,11 +10,10 @@ import androidx.annotation.StringRes;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListAdapter;
 import com.afollestad.materialdialogs.simplelist.MaterialSimpleListItem;
+import com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker;
 import com.perflyst.twire.R;
 import com.perflyst.twire.views.LayoutSelector;
 import com.rey.material.widget.Slider;
-
-import biz.kasual.materialnumberpicker.MaterialNumberPicker;
 
 /**
  * Created by Sebastian Rask on 02-05-2016.

--- a/app/src/main/res/layout/dialog_seek.xml
+++ b/app/src/main/res/layout/dialog_seek.xml
@@ -4,16 +4,15 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <biz.kasual.materialnumberpicker.MaterialNumberPicker
+    <com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker
         android:id="@+id/hour_picker"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintEnd_toStartOf="@id/colon_separator"
         app:layout_constraintStart_toStartOf="parent"
-        app:npBackgroundColor="?attr/navigationDrawerBackground"
-        app:npMinValue="0"
-        app:npTextColor="?attr/navigationDrawerTextColor"
-        app:npTextSize="@dimen/stream_sleep_timer_font_size" />
+        app:mnpMinValue="0"
+        app:mnpTextColor="?attr/navigationDrawerTextColor"
+        app:mnpTextSize="@dimen/stream_sleep_timer_font_size" />
 
     <TextView
         android:id="@+id/colon_separator"
@@ -27,16 +26,15 @@
         app:layout_constraintStart_toEndOf="@id/hour_picker"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <biz.kasual.materialnumberpicker.MaterialNumberPicker
+    <com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker
         android:id="@+id/minute_picker"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintEnd_toStartOf="@id/colon_separator_2"
         app:layout_constraintStart_toEndOf="@id/colon_separator"
-        app:npBackgroundColor="?attr/navigationDrawerBackground"
-        app:npMinValue="0"
-        app:npTextColor="?attr/navigationDrawerTextColor"
-        app:npTextSize="@dimen/stream_sleep_timer_font_size" />
+        app:mnpMinValue="0"
+        app:mnpTextColor="?attr/navigationDrawerTextColor"
+        app:mnpTextSize="@dimen/stream_sleep_timer_font_size" />
 
 
     <TextView
@@ -51,14 +49,13 @@
         app:layout_constraintStart_toEndOf="@id/minute_picker"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <biz.kasual.materialnumberpicker.MaterialNumberPicker
+    <com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker
         android:id="@+id/second_picker"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/colon_separator_2"
-        app:npBackgroundColor="?attr/navigationDrawerBackground"
-        app:npMinValue="0"
-        app:npTextColor="?attr/navigationDrawerTextColor"
-        app:npTextSize="@dimen/stream_sleep_timer_font_size" />
+        app:mnpMinValue="0"
+        app:mnpTextColor="?attr/navigationDrawerTextColor"
+        app:mnpTextSize="@dimen/stream_sleep_timer_font_size" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -11,16 +11,15 @@
         android:layout_centerInParent="true"
         android:orientation="horizontal">
 
-        <biz.kasual.materialnumberpicker.MaterialNumberPicker
+        <com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker
             android:id="@+id/hourPicker"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            app:npBackgroundColor="?attr/navigationDrawerBackground"
-            app:npDefaultValue="0"
-            app:npMaxValue="24"
-            app:npMinValue="0"
-            app:npTextColor="?attr/navigationDrawerTextColor"
-            app:npTextSize="@dimen/stream_sleep_timer_font_size" />
+            app:mnpMaxValue="24"
+            app:mnpMinValue="0"
+            app:mnpTextColor="?attr/navigationDrawerTextColor"
+            app:mnpTextSize="@dimen/stream_sleep_timer_font_size"
+            app:mnpValue="0" />
 
         <FrameLayout
             android:layout_width="wrap_content"
@@ -46,16 +45,15 @@
             android:textColor="?attr/navigationDrawerTextColor"
             android:textSize="@dimen/stream_sleep_timer_font_size" />
 
-        <biz.kasual.materialnumberpicker.MaterialNumberPicker
+        <com.github.stephenvinouze.materialnumberpickercore.MaterialNumberPicker
             android:id="@+id/minutePicker"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            app:npBackgroundColor="?attr/navigationDrawerBackground"
-            app:npDefaultValue="15"
-            app:npMaxValue="59"
-            app:npMinValue="0"
-            app:npTextColor="?attr/navigationDrawerTextColor"
-            app:npTextSize="@dimen/stream_sleep_timer_font_size" />
+            app:mnpMaxValue="59"
+            app:mnpMinValue="0"
+            app:mnpTextColor="?attr/navigationDrawerTextColor"
+            app:mnpTextSize="@dimen/stream_sleep_timer_font_size"
+            app:mnpValue="15" />
     </LinearLayout>
 
     <TextView

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-// FIXME: Wait for MaterialNumberPicker before removing jcenter
-//  https://github.com/google/ExoPlayer/issues/5246
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
     }
@@ -21,7 +18,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-// FIXME: Wait for MaterialNumberPicker and ExoPlayer before removing jcenter
+// FIXME: Wait for MaterialNumberPicker before removing jcenter
 //  https://github.com/google/ExoPlayer/issues/5246
 buildscript {
     repositories {
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 1st commit
- Update Android Studio 4.1.2 -> 4.2.1
- Update Gradle 6.7.1 -> 7.0.2
- Update NDK 22.0 -> 22.1
- Update RecyclerView 1.1.0 -> 1.2.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/recyclerview#version_120_3)) (we may want to check out ConcatAdapter and see if we can utilize it somehow)
- Update Transition 1.4.0 -> 1.4.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/transition#version_141_3))
- Update Material 1.2.1 -> 1.3.0 ([changelog](https://github.com/material-components/material-components-android/releases/tag/1.3.0))
- Update Gson 2.8.6 -> 2.8.7 ([changelog](https://github.com/google/gson/blob/master/CHANGELOG.md))
- Update Conscrypt 2.5.1 -> 2.5.2 ([changelog](https://github.com/google/conscrypt/compare/2.5.1...2.5.2))

### 2nd commit
- Migrate MaterialNumberPicker to newer library ([releases](https://github.com/StephenVinouze/MaterialNumberPicker/releases))
- Finally remove jcenter() yay
