### PR TITLE
Add settings option for the player-type

### DIFF
--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsStreamPlayerActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsStreamPlayerActivity.java
@@ -71,7 +71,7 @@ public class SettingsStreamPlayerActivity extends ThemeActivity {
 
     private void updateSummaries() {
         String[] types = getResources().getStringArray(R.array.PlayerType);
-        mPlayerTypeSummary.setText(types[settings.getStreamPlayerType() - 1]);
+        mPlayerTypeSummary.setText(types[settings.getStreamPlayerType()]);
         updateSummary(mShowViewCountView, mShowViewCountSummary, settings.getStreamPlayerShowViewerCount());
         updateSummary(mShowRuntimeView, mShowRuntimeSummary, settings.getStreamPlayerRuntime());
         updateSummary(mShowNavigationBarView, mShowNavigationBarSummary, settings.getStreamPlayerShowNavigationBar());
@@ -99,9 +99,9 @@ public class SettingsStreamPlayerActivity extends ThemeActivity {
     }
 
     public void onClickPlayerType(View _view) {
-        MaterialDialog dialog = DialogService.getChooseChatSizeDialog
+        MaterialDialog dialog = DialogService.getChoosePlayerTypeDialog
                 (this, R.string.player_type, R.array.PlayerType, settings.getStreamPlayerType(), (dialog1, itemView, which, text) -> {
-                    settings.setStreamPlayerType(which + 1);
+                    settings.setStreamPlayerType(which);
                     updateSummaries();
                     return true;
                 });

--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsStreamPlayerActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsStreamPlayerActivity.java
@@ -9,14 +9,16 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.perflyst.twire.R;
 import com.perflyst.twire.activities.ThemeActivity;
+import com.perflyst.twire.service.DialogService;
 import com.perflyst.twire.service.Settings;
 
 public class SettingsStreamPlayerActivity extends ThemeActivity {
 
     private Settings settings;
-    private TextView mShowViewCountSummary, mShowNavigationBarSummary, mAutoPlaybackSummary;
+    private TextView mShowViewCountSummary, mShowNavigationBarSummary, mAutoPlaybackSummary, mPlayerTypeSummary;
     private CheckedTextView mShowViewCountView, mShowNavigationBarView, mAutoPlaybackView;
 
     @Override
@@ -28,6 +30,7 @@ public class SettingsStreamPlayerActivity extends ThemeActivity {
         mShowNavigationBarView = findViewById(R.id.player_show_navigation_title);
         mShowViewCountView = findViewById(R.id.player_show_viewercount_title);
         mAutoPlaybackView = findViewById(R.id.player_auto_continue_playback_title);
+        mPlayerTypeSummary = findViewById(R.id.player_type_summary);
 
         mShowViewCountSummary = findViewById(R.id.player_show_viewercount_title_summary);
         mShowNavigationBarSummary = findViewById(R.id.player_show_navigation_summary);
@@ -65,6 +68,8 @@ public class SettingsStreamPlayerActivity extends ThemeActivity {
     }
 
     private void updateSummaries() {
+        String[] types = getResources().getStringArray(R.array.PlayerType);
+        mPlayerTypeSummary.setText(types[settings.getStreamPlayerType() - 1]);
         updateSummary(mShowViewCountView, mShowViewCountSummary, settings.getStreamPlayerShowViewerCount());
         updateSummary(mShowNavigationBarView, mShowNavigationBarSummary, settings.getStreamPlayerShowNavigationBar());
         updateSummary(mAutoPlaybackView, mAutoPlaybackSummary, settings.getStreamPlayerAutoContinuePlaybackOnReturn());
@@ -84,4 +89,15 @@ public class SettingsStreamPlayerActivity extends ThemeActivity {
         settings.setStreamPlayerAutoContinuePlaybackOnReturn(!settings.getStreamPlayerAutoContinuePlaybackOnReturn());
         updateSummaries();
     }
+
+    public void onClickPlayerType(View _view) {
+        MaterialDialog dialog = DialogService.getChooseChatSizeDialog
+                (this, R.string.player_type, R.array.PlayerType, settings.getStreamPlayerType(), (dialog1, itemView, which, text) -> {
+                    settings.setStreamPlayerType(which + 1);
+                    updateSummaries();
+                    return true;
+                });
+        dialog.show();
+    }
+
 }

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -1418,10 +1418,10 @@ public class StreamFragment extends Fragment implements Player.Listener {
 
         if (vodId == null) {
             GetLiveStreamURL task = new GetLiveStreamURL(callback);
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mChannelInfo.getStreamerName(), types[settings.getStreamPlayerType() - 1]);
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mChannelInfo.getStreamerName(), types[settings.getStreamPlayerType()]);
         } else {
             GetLiveStreamURL task = new GetVODStreamURL(callback);
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, vodId.substring(1), types[settings.getStreamPlayerType() - 1]);
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, vodId.substring(1), types[settings.getStreamPlayerType()]);
         }
     }
 

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -128,6 +128,7 @@ public class StreamFragment extends Fragment implements Player.Listener {
             hasPaused = false,
             seeking = false;
     private ChannelInfo mChannelInfo;
+    private String[] types;
     private String vodId;
     private HeadsetPlugIntentReceiver headsetIntentReceiver;
     private Settings settings;
@@ -1353,12 +1354,14 @@ public class StreamFragment extends Fragment implements Player.Listener {
             }
         };
 
+        String[] types = getResources().getStringArray(R.array.PlayerType);
+
         if (vodId == null) {
             GetLiveStreamURL task = new GetLiveStreamURL(callback);
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mChannelInfo.getStreamerName());
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mChannelInfo.getStreamerName(), types[settings.getStreamPlayerType() - 1]);
         } else {
             GetLiveStreamURL task = new GetVODStreamURL(callback);
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, vodId.substring(1));
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, vodId.substring(1), types[settings.getStreamPlayerType() - 1]);
         }
     }
 

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -139,7 +139,6 @@ public class StreamFragment extends Fragment implements Player.Listener {
             seeking = false,
             runtime = false;
     private ChannelInfo mChannelInfo;
-    private String[] types;
     private String vodId;
     private HeadsetPlugIntentReceiver headsetIntentReceiver;
     private Settings settings;

--- a/app/src/main/java/com/perflyst/twire/service/DialogService.java
+++ b/app/src/main/java/com/perflyst/twire/service/DialogService.java
@@ -154,6 +154,18 @@ public class DialogService {
                 .build();
     }
 
+    public static MaterialDialog getChoosePlayerTypeDialog(Activity activity, @StringRes int dialogTitle, @ArrayRes int array, int currentSize, MaterialDialog.ListCallbackSingleChoice callbackSingleChoice) {
+        int indexOfPage = currentSize;
+        String[] playerTypes = activity.getResources().getStringArray(array);
+
+        return getBaseThemedDialog(activity)
+                .title(dialogTitle)
+                .itemsCallbackSingleChoice(indexOfPage, callbackSingleChoice)
+                .items(playerTypes)
+                .positiveText(R.string.done)
+                .build();
+    }
+
     public static MaterialDialog getSleepTimerDialog(Activity activity, boolean isTimerRunning, MaterialDialog.SingleButtonCallback onStartCallback, MaterialDialog.SingleButtonCallback onStopCallBack, int hourValue, int minuteValue) {
 
         @StringRes int positiveText = isTimerRunning ? R.string.resume : R.string.start;

--- a/app/src/main/java/com/perflyst/twire/service/Settings.java
+++ b/app/src/main/java/com/perflyst/twire/service/Settings.java
@@ -37,7 +37,8 @@ public class Settings {
     private final String NOTIFICATIONS_IS_DISABLED = "notIsDisabled";
     private final String STREAM_PLAYER_SHOW_VIEWERCOUNT = "streamPlayerShowViewerCount",
             STREAM_PLAYER_REVEAL_NAVIGATION = "streamPlayerRevealNavigation",
-            STREAM_PLAYER_AUTO_PLAYBACK = "streamPlayerAutoPlackbackOnReturn";
+            STREAM_PLAYER_AUTO_PLAYBACK = "streamPlayerAutoPlackbackOnReturn",
+            STREAM_PLAYER_TYPE = "streamPlayerType";
     private final String APPEARANCE_STREAM_STYLE = "appStreamStyle";
     private final String APPEARANCE_GAME_STYLE = "appGameStyle";
     private final String APPEARANCE_FOLLOW_STYLE = "appFollowStyle";
@@ -698,6 +699,21 @@ public class Settings {
     public boolean getStreamPlayerAutoContinuePlaybackOnReturn() {
         SharedPreferences preferences = getPreferences();
         return preferences.getBoolean(this.STREAM_PLAYER_AUTO_PLAYBACK, false);
+    }
+
+    /**
+     * Stream Player - Type
+     */
+
+    public int getStreamPlayerType() {
+        SharedPreferences preferences = getPreferences();
+        return preferences.getInt(this.STREAM_PLAYER_TYPE, 1);
+    }
+
+    public void setStreamPlayerType(int playerType) {
+        SharedPreferences.Editor editor = getEditor();
+        editor.putInt(this.STREAM_PLAYER_TYPE, playerType);
+        editor.commit();
     }
 
     /**

--- a/app/src/main/java/com/perflyst/twire/service/Settings.java
+++ b/app/src/main/java/com/perflyst/twire/service/Settings.java
@@ -719,7 +719,7 @@ public class Settings {
 
     public int getStreamPlayerType() {
         SharedPreferences preferences = getPreferences();
-        return preferences.getInt(this.STREAM_PLAYER_TYPE, 1);
+        return preferences.getInt(this.STREAM_PLAYER_TYPE, 0);
     }
 
     public void setStreamPlayerType(int playerType) {

--- a/app/src/main/java/com/perflyst/twire/tasks/GetLiveStreamURL.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetLiveStreamURL.java
@@ -35,7 +35,7 @@ public class GetLiveStreamURL extends AsyncTask<String, Void, LinkedHashMap<Stri
         callback = aCallback;
     }
 
-    protected String formatQuery(boolean isLive, String channelOrVod) {
+    protected String formatQuery(boolean isLive, String channelOrVod, String PlayerType) {
         return "{\n" +
                 "    \"operationName\": \"PlaybackAccessToken\",\n" +
                 "    \"extensions\": {\n" +
@@ -49,7 +49,7 @@ public class GetLiveStreamURL extends AsyncTask<String, Void, LinkedHashMap<Stri
                 "        \"login\": \"" + (isLive ? channelOrVod : "") + "\",\n" +
                 "        \"isVod\": " + !isLive + ",\n" +
                 "        \"vodID\": \"" + (!isLive ? channelOrVod : "") + "\",\n" +
-                "        \"playerType\": \"embed\"\n" +
+                "        \"playerType\": \""+ PlayerType + "\"\n" +
                 "    }\n" +
                 "}";
     }
@@ -57,13 +57,14 @@ public class GetLiveStreamURL extends AsyncTask<String, Void, LinkedHashMap<Stri
     @Override
     protected LinkedHashMap<String, Quality> doInBackground(String... params) {
         String streamerName = params[0];
+        String PlayerType = params[1];
         String signature = "";
         String token = "";
 
         Request request = new Request.Builder()
                 .url("https://gql.twitch.tv/gql")
                 .header("Client-ID", SecretKeys.TWITCH_WEB_CLIENT_ID)
-                .post(RequestBody.create(MediaType.get("application/json"), formatQuery(true, streamerName)))
+                .post(RequestBody.create(MediaType.get("application/json"), formatQuery(true, streamerName, PlayerType)))
                 .build();
 
         String resultString = Service.urlToJSONString(request);

--- a/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
@@ -28,13 +28,14 @@ public class GetVODStreamURL extends GetLiveStreamURL {
     @Override
     protected LinkedHashMap<String, Quality> doInBackground(String... params) {
         String vodId = params[0];
+        String PlayerType = params[1];
         String signature = "";
         String token = "";
 
         Request request = new Request.Builder()
                 .url("https://gql.twitch.tv/gql")
                 .header("Client-ID", SecretKeys.TWITCH_WEB_CLIENT_ID)
-                .post(RequestBody.create(MediaType.get("application/json"), formatQuery(false, vodId)))
+                .post(RequestBody.create(MediaType.get("application/json"), formatQuery(false, vodId, PlayerType)))
                 .build();
 
         String resultString = Service.urlToJSONString(request);

--- a/app/src/main/res/layout/activity_settings_stream_player.xml
+++ b/app/src/main/res/layout/activity_settings_stream_player.xml
@@ -145,6 +145,43 @@
                 android:layout_height="@dimen/settings_divider_height"
                 android:background="?attr/dividerColor" />
 
+            <com.balysv.materialripple.MaterialRippleLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:mrl_rippleDelayClick="false">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/settings_small_item_height"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:onClick="onClickPlayerType">
+
+                    <TextView
+                        android:id="@+id/player_type_title"
+                        style="@style/text_settings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/player_type"
+                        android:textAppearance="@style/text_settings_title" />
+
+                    <TextView
+                        android:id="@+id/player_type_summary"
+                        style="@style/text_settings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/player_type_title"
+                        android:textAppearance="@style/sub_text_settings" />
+                </RelativeLayout>
+            </com.balysv.materialripple.MaterialRippleLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/settings_divider_height"
+                android:background="?attr/dividerColor" />
+
         </LinearLayout>
     </ScrollView>
+
 </RelativeLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -44,4 +44,11 @@
         <item>@string/chat_size_high</item>
     </string-array>
 
+    <string-array name="PlayerType">
+        <item>embed</item>
+        <item>site</item>
+        <item>thunderdome</item>
+        <item>picture-by-picture</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="player_show_viewercount">Show viewer count</string>
     <string name="player_show_navigation">Reveal navigation bar on click</string>
     <string name="player_auto_player">Continue playback when returning</string>
+    <string name="player_type">Stream Player Type</string>
 
     <!-- Appearance settings -->
     <string name="appearance_theme_color_title">Theme</string>
@@ -280,7 +281,6 @@
     <!-- Changelog -->
     <string name="changelog_title">Changelog</string>
     <string name="changelog_show_after_update">Show changelog after an update</string>
-    <string name="player_type">Stream Player Type</string>
 
     <!-- The first letter of each line of the changelog denotes if it's about a new Version, Addition, Fix or Change and should not be translated. -->
     <string-array name="changelog_lines">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,6 +280,7 @@
     <!-- Changelog -->
     <string name="changelog_title">Changelog</string>
     <string name="changelog_show_after_update">Show changelog after an update</string>
+    <string name="player_type">Stream Player Type</string>
 
     <!-- The first letter of each line of the changelog denotes if it's about a new Version, Addition, Fix or Change and should not be translated. -->
     <string-array name="changelog_lines">


### PR DESCRIPTION
This pull request adds a settings option for the Stream-Player-Type.

# Usecase:
- This can serve as Ad-Blocker
- Can be used to bypass possible problems in the future (e.g. if they disable the embed player, then users can swap directly without waiting for an update).

# There are differences between the player-types:
Player-Type | info
------------ | -------------
embed | has ads, all resolutions
site | has ads, all resolutions
thunderdome | has no ads, limited to 480p
picture-in-picture | has no ads, limited to 360p

Source:
https://github.com/saucettv/AdFreeBut480pForTwitch/blob/main/content.js
https://raw.githubusercontent.com/pixeltris/TwitchAdSolutions/master/low-res/low-res.user.js