### PR TITLE
fix runnable duplication (runtime duplication)

### DIFF
--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -137,7 +137,8 @@ public class StreamFragment extends Fragment implements Player.Listener {
             autoPlay = true,
             hasPaused = false,
             seeking = false,
-            runtime = false;
+            runtime = false,
+            runtimerunning = false;
     private ChannelInfo mChannelInfo;
     private String vodId;
     private HeadsetPlugIntentReceiver headsetIntentReceiver;
@@ -201,6 +202,7 @@ public class StreamFragment extends Fragment implements Player.Listener {
     private final Runnable runtimeRunnable = new Runnable() {
         @Override
         public void run() {
+            runtimerunning = true;
             // handle the Stream runtime here
             if (runtime) {
                 Calendar calendar = Calendar.getInstance();
@@ -587,7 +589,9 @@ public class StreamFragment extends Fragment implements Player.Listener {
             mediaSession.setActive(true);
 
             progressHandler.postDelayed(progressRunnable, 1000);
-            runtimeHandler.postDelayed(runtimeRunnable, 1000);
+            if (!runtimerunning) {
+                runtimeHandler.postDelayed(runtimeRunnable, 1000);
+            }
         }
     }
 

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -137,8 +137,7 @@ public class StreamFragment extends Fragment implements Player.Listener {
             autoPlay = true,
             hasPaused = false,
             seeking = false,
-            runtime = false,
-            runtimerunning = false;
+            runtime = false;
     private ChannelInfo mChannelInfo;
     private String vodId;
     private HeadsetPlugIntentReceiver headsetIntentReceiver;
@@ -202,7 +201,6 @@ public class StreamFragment extends Fragment implements Player.Listener {
     private final Runnable runtimeRunnable = new Runnable() {
         @Override
         public void run() {
-            runtimerunning = true;
             // handle the Stream runtime here
             if (runtime) {
                 Calendar calendar = Calendar.getInstance();
@@ -393,6 +391,7 @@ public class StreamFragment extends Fragment implements Player.Listener {
         });
 
         initializePlayer();
+        runtimeHandler.postDelayed(runtimeRunnable, 1000);
 
         mRootView.setOnSystemUiVisibilityChangeListener(
                 visibility -> {
@@ -589,9 +588,6 @@ public class StreamFragment extends Fragment implements Player.Listener {
             mediaSession.setActive(true);
 
             progressHandler.postDelayed(progressRunnable, 1000);
-            if (!runtimerunning) {
-                runtimeHandler.postDelayed(runtimeRunnable, 1000);
-            }
         }
     }
 


### PR DESCRIPTION
### Problem
When locking the Device Screen a new runnable for the runtimetime gets launched. This is adding +1 second for every lock/unlock.

## Bug
[![](https://img.youtube.com/vi/Ip7wA2R6HLE/0.jpg)](https://www.youtube.com/watch?v=Ip7wA2R6HLE)

## Fix
[![](https://img.youtube.com/vi/DN_Y7TPGC4M/0.jpg)](https://www.youtube.com/watch?v=DN_Y7TPGC4M)