### PR TITLE
Add basic privacy options

### DIFF
--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
@@ -2,9 +2,11 @@ package com.perflyst.twire.activities.settings;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CheckedTextView;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -23,9 +25,11 @@ import com.perflyst.twire.service.Service;
 import com.perflyst.twire.service.Settings;
 
 public class SettingsGeneralActivity extends ThemeActivity {
+    private final String LOG_TAG = getClass().getSimpleName();
     private Settings settings;
-    private TextView twitchNameView, startPageSubText;
-    private CheckedTextView filterTopStreamsByLanguageView;
+    private TextView twitchNameView, startPageSubText, general_image_proxy_summary;
+    private CheckedTextView filterTopStreamsByLanguageView, general_image_proxy;
+    private EditText mImageProxyUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,6 +48,12 @@ public class SettingsGeneralActivity extends ThemeActivity {
         startPageSubText = findViewById(R.id.start_page_sub_text);
         filterTopStreamsByLanguageView = findViewById(R.id.language_filter_title);
 
+        general_image_proxy_summary = findViewById(R.id.general_image_proxy_summary);
+        general_image_proxy = findViewById(R.id.general_image_proxy);
+        mImageProxyUrl = findViewById(R.id.image_proxy_url_input);
+
+        mImageProxyUrl.setText(settings.getImageProxyUrl());
+
         initTwitchDisplayName();
         initStartPageText();
         initFilterTopsStreamsByLanguage();
@@ -60,6 +70,20 @@ public class SettingsGeneralActivity extends ThemeActivity {
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         onBackPressed();
         return super.onOptionsItemSelected(item);
+    }
+
+    private void updateSummary(CheckedTextView checkView, TextView summary, boolean isEnabled) {
+        checkView.setChecked(isEnabled);
+        if (isEnabled) {
+            summary.setText(getString(R.string.enabled));
+        } else {
+            summary.setText(getString(R.string.disabled));
+        }
+    }
+
+    private void updateSummaries() {
+        updateSummary(general_image_proxy, general_image_proxy_summary, settings.getGeneralUseImageProxy());
+        mImageProxyUrl.setText(settings.getImageProxyUrl());
     }
 
     private void initStartPageText() {
@@ -141,4 +165,20 @@ public class SettingsGeneralActivity extends ThemeActivity {
     public void onClickOpenChangelog(View v) {
         new ChangelogDialogFragment().show(getSupportFragmentManager(), "ChangelogDialog");
     }
+
+    public void onClickImageProxy(View v) {
+        settings.setGeneralUseImageProxy(!settings.getGeneralUseImageProxy());
+        updateSummaries();
+    }
+
+    public void onClickImageProxyUrl(View v) {
+        if (mImageProxyUrl.getText().toString().contains("http://") | mImageProxyUrl.getText().toString().contains("https://")) {
+            settings.setImageProxyUrl(mImageProxyUrl.getText().toString());
+            Log.d(LOG_TAG, "Setting as Image Proxy: " + mImageProxyUrl.getText().toString());
+            updateSummaries();
+        } else {
+            Log.d(LOG_TAG, "Url looks wrong" + mImageProxyUrl.getText().toString());
+        }
+    }
+
 }

--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
@@ -3,6 +3,7 @@ package com.perflyst.twire.activities.settings;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.util.Patterns;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CheckedTextView;
@@ -23,6 +24,8 @@ import com.perflyst.twire.fragments.ChangelogDialogFragment;
 import com.perflyst.twire.service.DialogService;
 import com.perflyst.twire.service.Service;
 import com.perflyst.twire.service.Settings;
+
+import java.util.regex.Matcher;
 
 public class SettingsGeneralActivity extends ThemeActivity {
     private final String LOG_TAG = getClass().getSimpleName();
@@ -172,12 +175,16 @@ public class SettingsGeneralActivity extends ThemeActivity {
     }
 
     public void onClickImageProxyUrl(View v) {
-        if (mImageProxyUrl.getText().toString().contains("http://") | mImageProxyUrl.getText().toString().contains("https://")) {
-            settings.setImageProxyUrl(mImageProxyUrl.getText().toString());
-            Log.d(LOG_TAG, "Setting as Image Proxy: " + mImageProxyUrl.getText().toString());
+        String proxy_url = mImageProxyUrl.getText().toString();
+
+        // app/src/main/java/com/perflyst/twire/activities/DeepLinkActivity.java 115
+        Matcher matcher = Patterns.WEB_URL.matcher(proxy_url);
+        if (matcher.find()) {
+            settings.setImageProxyUrl(proxy_url);
+            Log.d(LOG_TAG, "Setting as Image Proxy: " + proxy_url);
             updateSummaries();
         } else {
-            Log.d(LOG_TAG, "Url looks wrong" + mImageProxyUrl.getText().toString());
+            Log.d(LOG_TAG, "Url looks wrong" + proxy_url);
         }
     }
 

--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsGeneralActivity.java
@@ -52,7 +52,7 @@ public class SettingsGeneralActivity extends ThemeActivity {
         general_image_proxy = findViewById(R.id.general_image_proxy);
         mImageProxyUrl = findViewById(R.id.image_proxy_url_input);
 
-        mImageProxyUrl.setText(settings.getImageProxyUrl());
+        updateSummaries();
 
         initTwitchDisplayName();
         initStartPageText();

--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsTwitchChatActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsTwitchChatActivity.java
@@ -17,8 +17,8 @@ import com.perflyst.twire.service.Settings;
 
 public class SettingsTwitchChatActivity extends ThemeActivity {
     private Settings settings;
-    private TextView emoteSizeSummary, messageSizeSummary, chatLandscapeWidthSummary, chatLandscapeToggleSummary, chatLandscapeSwipeToShowSummary, chat_enable_ssl_summary;
-    private CheckedTextView chatLandscapeToggle, chatSwipeToShowToggle, chat_enable_ssl;
+    private TextView emoteSizeSummary, messageSizeSummary, chatLandscapeWidthSummary, chatLandscapeToggleSummary, chatLandscapeSwipeToShowSummary, chat_enable_ssl_summary, chat_enable_account_connect_summary;
+    private CheckedTextView chatLandscapeToggle, chatSwipeToShowToggle, chat_enable_ssl, chat_enable_account_connect;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,10 +38,12 @@ public class SettingsTwitchChatActivity extends ThemeActivity {
         chatLandscapeToggleSummary = findViewById(R.id.chat_landscape_enable_summary);
         chatLandscapeSwipeToShowSummary = findViewById(R.id.chat_landscape_swipe_summary);
         chat_enable_ssl_summary = findViewById(R.id.chat_enable_ssl_summary);
+        chat_enable_account_connect_summary = findViewById(R.id.chat_enable_account_connect_summary);
 
         chatLandscapeToggle = findViewById(R.id.chat_landscape_enable_title);
         chatSwipeToShowToggle = findViewById(R.id.chat_landscape_swipe_title);
         chat_enable_ssl = findViewById(R.id.chat_enable_ssl);
+        chat_enable_account_connect = findViewById(R.id.chat_enable_account_connect);
         updateSummaries();
     }
 
@@ -66,6 +68,8 @@ public class SettingsTwitchChatActivity extends ThemeActivity {
         updateSummary(chatSwipeToShowToggle, chatLandscapeSwipeToShowSummary, settings.isChatLandscapeSwipeable());
         // Chat SSL Enabled
         updateSummary(chat_enable_ssl, chat_enable_ssl_summary, settings.getChatEnableSSL());
+        // Chat enable Login with Account
+        updateSummary(chat_enable_account_connect, chat_enable_account_connect_summary, settings.getChatAccountConnect());
     }
 
     @Override
@@ -113,6 +117,11 @@ public class SettingsTwitchChatActivity extends ThemeActivity {
 
     public void onClickChatEnableSSL(View _view) {
         settings.setChatEnableSSL(!settings.getChatEnableSSL());
+        updateSummaries();
+    }
+
+    public void onClickChatAccountConnect(View _view) {
+        settings.setChatAccountConnect(!settings.getChatAccountConnect());
         updateSummaries();
     }
 

--- a/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
+++ b/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
@@ -86,7 +86,9 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
         mEmoteManager = new ChatEmoteManager(aChannel, aChannelUserId);
         Settings appSettings = new Settings(aContext);
 
-        if (appSettings.isLoggedIn()) { // if user is logged in ...
+        Log.d(LOG_TAG, "Login with main Account: " + appSettings.getChatAccountConnect());
+
+        if (appSettings.isLoggedIn() && appSettings.getChatAccountConnect()) { // if user is logged in ...
             // ... use their credentials
             Log.d(LOG_TAG, "Using user credentials for chat login.");
 
@@ -112,7 +114,7 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
         else {
             twitchChatPort = twitchChatPortunsecure;
         }
-        Log.d("Use SSL Chat Server", String.valueOf(appSettings.getChatEnableSSL()));
+        Log.d(LOG_TAG, "Use SSL Chat Server: " + appSettings.getChatEnableSSL());
 
         executeOnExecutor(THREAD_POOL_EXECUTOR);
     }

--- a/app/src/main/java/com/perflyst/twire/fragments/ChatFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/ChatFragment.java
@@ -178,7 +178,7 @@ public class ChatFragment extends Fragment implements EmoteKeyboardDelegate, Cha
         mChannelInfo = requireArguments().getParcelable(getString(R.string.stream_fragment_streamerInfo));// intent.getParcelableExtra(getResources().getString(R.string.intent_key_streamer_info));
         vodID = requireArguments().getString(getString(R.string.stream_fragment_vod_id));
 
-        if (!settings.isLoggedIn() || vodID != null) {
+        if (!settings.isLoggedIn() || vodID != null || !settings.getChatAccountConnect()) {
             userNotLoggedIn();
         } else {
             setupChatInput();

--- a/app/src/main/java/com/perflyst/twire/service/JSONService.java
+++ b/app/src/main/java/com/perflyst/twire/service/JSONService.java
@@ -50,12 +50,14 @@ public class JSONService {
     }
 
     public static StreamInfo getStreamInfo(Context context, JSONObject streamObject, @Nullable ChannelInfo aChannelInfo, boolean loadDescription) throws JSONException, MalformedURLException {
+        Settings settings = new Settings(context);
         final String PREVIEW_LINK_OBJECT = "preview";
         final String CHANNEL_OBJECT = "channel";
         final String CHANNEL_STATUS_STRING = "status";
         final String GAME_STRING = "game";
         final String STREAM_START_TIME_STRING = "created_at";
         final String CURRENT_VIEWERS_INT = "viewers";
+        String prepend_image = "";
 
         final String PREVIEW_SMALL_STRING = "small";
         final String PREVIEW_MEDIUM_STRING = "medium";
@@ -75,10 +77,14 @@ public class JSONService {
             Log.i(LOG_TAG, "Status/title for " + mChannelInfo.getDisplayName() + " is null");
         }
 
+        if (settings.getGeneralUseImageProxy()) {
+            prepend_image = settings.getImageProxyUrl();
+        }
+
         String[] previews = {
-                JSONPreview.getString(PREVIEW_SMALL_STRING),
-                JSONPreview.getString(PREVIEW_MEDIUM_STRING),
-                JSONPreview.getString(PREVIEW_LARGE_STRING),
+                prepend_image + JSONPreview.getString(PREVIEW_SMALL_STRING),
+                prepend_image + JSONPreview.getString(PREVIEW_MEDIUM_STRING),
+                prepend_image + JSONPreview.getString(PREVIEW_LARGE_STRING),
         };
 
         String startedAtString = streamObject.getString(STREAM_START_TIME_STRING);

--- a/app/src/main/java/com/perflyst/twire/service/Settings.java
+++ b/app/src/main/java/com/perflyst/twire/service/Settings.java
@@ -63,6 +63,7 @@ public class Settings {
     private final String CHAT_LANDSCAPE_SWIPEABLE = "chatLandscapeSwipable";
     private final String CHAT_LANDSCAPE_WIDTH = "chatLandscapeWidth";
     private final String CHAT_ENABLE_SSL = "chatEnableSSL";
+    private final String CHAT_ACCOUNT_CONNECT = "chatAccountConnect";
     private final String CHAT_RECENT_EMOTES = "chatRecentEmotes";
     private final String CHAT_KEYBOARD_HEIGHT = "chatKeyboardHeight";
     private final String NOTIFY_LIVE = "notifyUserLive";
@@ -788,6 +789,21 @@ public class Settings {
     public void setChatEnableSSL(boolean SSL) {
         SharedPreferences.Editor editor = getEditor();
         editor.putBoolean(this.CHAT_ENABLE_SSL, SSL);
+        editor.commit();
+    }
+
+    /**
+     * Chat - Connect with Account
+     */
+
+    public boolean getChatAccountConnect() {
+        SharedPreferences preferences = getPreferences();
+        return preferences.getBoolean(this.CHAT_ACCOUNT_CONNECT, true);
+    }
+
+    public void setChatAccountConnect(boolean AccountConnect) {
+        SharedPreferences.Editor editor = getEditor();
+        editor.putBoolean(this.CHAT_ACCOUNT_CONNECT, AccountConnect);
         editor.commit();
     }
 

--- a/app/src/main/java/com/perflyst/twire/service/Settings.java
+++ b/app/src/main/java/com/perflyst/twire/service/Settings.java
@@ -34,6 +34,8 @@ public class Settings {
     private final String GENERAL_TWITCH_USER_IS_PARTNER = "genTwitchUserIsPartner";
     private final String GENERAL_TWITCH_USER_ID = "genTwitchUserID";
     private final String GENERAL_FILTER_TOP_STREAMS_LANGUAGE = "genFilterTopStreamLanguage";
+    private final String GENERAL_IMAGE_PROXY = "genImageProxy";
+    private final String GENERAL_IMAGE_PROXY_URL = "genImageProxyUrl";
     private final String NOTIFICATIONS_IS_DISABLED = "notIsDisabled";
     private final String STREAM_PLAYER_SHOW_VIEWERCOUNT = "streamPlayerShowViewerCount",
             STREAM_PLAYER_SHOW_RUNTIME = "streamPlayerShowRuntime",
@@ -804,6 +806,36 @@ public class Settings {
     public void setChatAccountConnect(boolean AccountConnect) {
         SharedPreferences.Editor editor = getEditor();
         editor.putBoolean(this.CHAT_ACCOUNT_CONNECT, AccountConnect);
+        editor.commit();
+    }
+
+    /**
+     * General - Use Image Proxy
+     */
+
+    public boolean getGeneralUseImageProxy() {
+        SharedPreferences preferences = getPreferences();
+        return preferences.getBoolean(this.GENERAL_IMAGE_PROXY, false);
+    }
+
+    public void setGeneralUseImageProxy(boolean ImageProxy) {
+        SharedPreferences.Editor editor = getEditor();
+        editor.putBoolean(this.GENERAL_IMAGE_PROXY, ImageProxy);
+        editor.commit();
+    }
+
+    /**
+     * General - Use Image Proxy Url
+     */
+
+    public String getImageProxyUrl() {
+        SharedPreferences preferences = getPreferences();
+        return String.valueOf(preferences.getString(this.GENERAL_IMAGE_PROXY_URL, "https://external-content.duckduckgo.com/iu/?u="));
+    }
+
+    public void setImageProxyUrl(String url) {
+        SharedPreferences.Editor editor = getEditor();
+        editor.putString(this.GENERAL_IMAGE_PROXY_URL, url);
         editor.commit();
     }
 

--- a/app/src/main/res/layout/activity_settings_general.xml
+++ b/app/src/main/res/layout/activity_settings_general.xml
@@ -188,6 +188,96 @@
                 android:layout_height="@dimen/settings_divider_height"
                 android:background="?attr/dividerColor" />
 
+            <com.balysv.materialripple.MaterialRippleLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:mrl_rippleDelayClick="false">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/settings_small_item_height"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:onClick="onClickImageProxy">
+
+                    <CheckedTextView
+                        android:id="@+id/general_image_proxy"
+                        style="@style/text_settings"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+
+                        android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                        android:gravity="center_vertical"
+                        android:text="@string/settings_general_image_proxy"
+                        android:textAppearance="@style/text_settings_title" />
+
+                    <TextView
+                        android:id="@+id/general_image_proxy_summary"
+                        style="@style/text_settings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/general_image_proxy"
+                        android:textAppearance="@style/sub_text_settings" />
+
+                </RelativeLayout>
+            </com.balysv.materialripple.MaterialRippleLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/settings_divider_height"
+                android:background="?attr/dividerColor" />
+
+            <com.balysv.materialripple.MaterialRippleLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:mrl_rippleDelayClick="false">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical">
+
+                    <EditText
+                        android:id="@+id/image_proxy_url_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
+                        android:layout_marginTop="10dp"
+                        android:ems="10"
+                        android:hint="API url"
+                        android:inputType="textUri"
+                        android:selectAllOnFocus="true" />
+
+                    <TextView
+                        android:id="@+id/player_proxy_url_info"
+                        style="@style/text_settings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/image_proxy_url_input"
+                        android:text="@string/settings_general_image_proxy_url_example"
+                        android:textAppearance="@style/sub_text_settings" />
+
+                    <Button
+                        android:id="@+id/image_proxy_url_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/player_proxy_url_info"
+                        android:layout_alignRight="@id/image_proxy_url_input"
+                        android:onClick="onClickImageProxyUrl"
+                        android:text="@string/settings_general_image_proxy_url_button" />
+
+                </RelativeLayout>
+            </com.balysv.materialripple.MaterialRippleLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/settings_divider_height"
+                android:background="?attr/dividerColor" />
+
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_settings_twitch_chat.xml
+++ b/app/src/main/res/layout/activity_settings_twitch_chat.xml
@@ -257,6 +257,47 @@
                 android:layout_height="@dimen/settings_divider_height"
                 android:background="?attr/dividerColor" />
 
+            <com.balysv.materialripple.MaterialRippleLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:mrl_rippleDelayClick="false">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/settings_small_item_height"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:onClick="onClickChatAccountConnect">
+
+                    <CheckedTextView
+                        android:id="@+id/chat_enable_account_connect"
+                        style="@style/text_settings"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+
+                        android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                        android:gravity="center_vertical"
+                        android:text="@string/chat_enable_account_connect"
+                        android:textAppearance="@style/text_settings_title" />
+
+                    <TextView
+                        android:id="@+id/chat_enable_account_connect_summary"
+                        style="@style/text_settings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/chat_enable_account_connect"
+                        android:textAppearance="@style/sub_text_settings" />
+
+                </RelativeLayout>
+            </com.balysv.materialripple.MaterialRippleLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/settings_divider_height"
+                android:background="?attr/dividerColor" />
+
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,7 @@
     <string name="chat_size_medium">Medium</string>
     <string name="chat_size_high">Large</string>
     <string name="chat_enable_ssl">Use SSL for the connection</string>
+    <string name="chat_enable_account_connect">Connect using your Account</string>
 
     <!-- Stream Player Settings -->
     <string name="player_show_viewercount">Show viewer count</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,9 @@
     <!-- Settings -->
     <string name="settings_general_name">General</string>
     <string name="settings_general_name_summary">Twitch account, startup page</string>
+    <string name="settings_general_image_proxy">Use an Image Proxy</string>
+    <string name="settings_general_image_proxy_url_button">Save</string>
+    <string name="settings_general_image_proxy_url_example">Example Proxy: https://external-content.duckduckgo.com/iu/?u=</string>
     <string name="settings_stream_player_name">Stream player</string>
     <string name="settings_stream_player_summary">Current viewer count, player behavior</string>
     <string name="settings_appearance_name">Appearance</string>


### PR DESCRIPTION
# Description

This Pull request is adding:
- an option to join the Chat anonymously while logged in
- an option to enable an image proxy / with a custom URL

# Anon Chat
- Disabled by Default
- Simple toggle added in Chat settings
- behaves the same as being locked out
![qemu-system-x86_64_yBlZoUP88c](https://user-images.githubusercontent.com/34883496/135270340-df5a1e0a-2754-40e1-ba12-8c25829b8ca5.png)

# Image Proxy
- Disabled by Default
- Toggle for enable/disable
- Option for Custom Proxy
- Default proxy is from duckduckgo (https://external-content.duckduckgo.com/iu/?u=)
![qemu-system-x86_64_vv3EerGHSp](https://user-images.githubusercontent.com/34883496/135270351-1b5c0fb3-d0f8-421d-9dbe-5df6713abace.png)