### PR TITLE
Fix broken emotes

### DIFF
--- a/app/src/main/java/com/perflyst/twire/service/Service.java
+++ b/app/src/main/java/com/perflyst/twire/service/Service.java
@@ -529,6 +529,38 @@ public class Service {
         return result;
     }
 
+    // new urlToJSONString for the helix API
+
+    public static String urlToJSONStringHelix(String urlToRead, String Token) {
+        String clientId = Service.getApplicationClientID();
+
+        Request request = new Request.Builder()
+                .url(urlToRead)
+                .header("Client-ID", clientId)
+                .header("Authorization", "Bearer " + Token)
+                .header("Accept", "application/json")
+                .build();
+
+        return urlToJSONStringHelix(request);
+    }
+
+    public static String urlToJSONStringHelix(Request request) {
+        SimpleResponse response = makeRequest(request);
+        if (response == null)
+            return null;
+
+        String result = response.body;
+
+        if (result.isEmpty() || result.length() >= 1 && result.charAt(0) != '{' && result.charAt(0) != '[') {
+            Log.v("URL TO JSON STRING", request.url() + " did not successfully get read");
+            Log.v("URL TO JSON STRING", "Result of reading - " + result);
+        }
+
+        return result;
+    }
+
+    // end new urlToJSONString
+
     public static SimpleResponse makeRequest(Request request) {
         Response response;
         try {

--- a/app/src/main/java/com/perflyst/twire/tasks/GetTwitchEmotesTask.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetTwitchEmotesTask.java
@@ -39,12 +39,13 @@ public class GetTwitchEmotesTask extends AsyncTask<Void, Void, Void> {
     @Override
     protected Void doInBackground(Void... voids) {
         Settings settings = new Settings(context.get());
+
+
+        /* Well so this has been broken at the moment because there is no replacement API. Please See: https://twitch.uservoice.com/forums/310213-developers/suggestions/43599900-get-the-authenticated-user-s-emotes-equivalent-to
         try {
-            String newUrl = "https://api.twitch.tv/helix/chat/emotes?broadcaster_id=" + settings.getGeneralTwitchUserID();
-            Log.d(LOG_TAG, newUrl);
+            String newUrl = "ADD API LINK HERE" + settings.getGeneralTwitchUserID();
             JSONObject top = new JSONObject(Service.urlToJSONStringHelix(newUrl, settings.getGeneralTwitchAccessToken()));
-            Log.d(LOG_TAG, top.toString());
-            String SETS_KEY = "";
+            String SETS_KEY = "data";
             JSONObject sets = top.getJSONObject(SETS_KEY);
             Iterator<?> setKeys = sets.keys();
 
@@ -69,6 +70,8 @@ public class GetTwitchEmotesTask extends AsyncTask<Void, Void, Void> {
         } catch (JSONException e) {
             e.printStackTrace();
         }
+        */
+
 
         try {
             String url = "https://api.twitch.tv/helix/chat/emotes/global";

--- a/app/src/main/java/com/perflyst/twire/tasks/GetTwitchEmotesTask.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetTwitchEmotesTask.java
@@ -84,7 +84,7 @@ public class GetTwitchEmotesTask extends AsyncTask<Void, Void, Void> {
                         .replaceAll("\\((.+)\\|.+\\)", "$1");
 
                 // this is a string now: example: emotesv2_89f3f0761c7b4f708061e9e4be3b7d17
-                String emoteId = "" + emoteObject.getString("id");
+                String emoteId = emoteObject.getString("id");
                 twitchEmotes.add(Emote.Twitch(code, emoteId));
             }
         } catch (JSONException e) {


### PR DESCRIPTION
# Description

## This Pull request is fixing:
- the broken emotes

## Issues Fixed
#245 

# Changes
**Since Twitch is switching more APIs over to helix (#236) we need to use it too. But the problem with that is that we need to send an Authorization Header with every request, so users that are not logged in with a Twitch Account get no emotes.**

# To-Do
- [ ] other emotes