### PR TITLE
Fix login reset

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,8 +108,9 @@
             android:name=".activities.setup.LoginActivity"
             android:label="@string/title_activity_login"
             android:parentActivityName=".activities.setup.WelcomeActivity"
-            android:screenOrientation="sensor">
-            <meta-data
+            android:screenOrientation="sensor"
+            android:configChanges="orientation|screenSize">
+        <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.setup.WelcomeActivity" />
         </activity>


### PR DESCRIPTION
# Issue
The ability to rotate the phone while logging in was implemented in #210 Because of this the login window would reset itself when rotated. The reason for this is that the onCreate event is called when rotating the device. (https://stackoverflow.com/questions/7618703/activity-lifecycle-oncreate-called-on-every-re-orientation)

# Fix
Add `android:configChanges="orientation|screenSize"` to the Login Activity

# Test
Tested on Xiaomi Redmi Note 7 with the current master version.

# Info 
The animations are still going to redraw, but it's still better than before.