### PR TITLE
Offer source quality for VODs

### DIFF
--- a/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
+++ b/app/src/main/java/com/perflyst/twire/tasks/GetVODStreamURL.java
@@ -51,7 +51,7 @@ public class GetVODStreamURL extends GetLiveStreamURL {
             e.printStackTrace();
         }
 
-        String vodURL = String.format("http://usher.twitch.tv/vod/%s?nauthsig=%s&nauth=%s", vodId, signature, safeEncode(token));
+        String vodURL = String.format("http://usher.twitch.tv/vod/%s?allow_source=true&nauthsig=%s&nauth=%s", vodId, signature, safeEncode(token));
         Log.d(LOG_TAG, "HSL Playlist URL: " + vodURL);
         return parseM3U8(vodURL);
     }


### PR DESCRIPTION
VODs didn't have the source quality because it needs to be explicitly requested.
If a VOD is muted the quality selection just says "Source" without specifying a resolution. That's the same behavior as on Twitch's website, so I think it's fine.