### PR TITLE
Fix crash when chat roomstate changes

### DIFF
--- a/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
+++ b/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
@@ -435,15 +435,23 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
      * If the roomstate has changed since last check variables are changed and the chatfragment is notified
      */
     private void handleRoomstate(IRCMessage message) {
-        boolean newR9k = message.tags.get("r9k").equals("1");
-        boolean newSlow = !message.tags.get("slow").equals("0");
-        boolean newSub = message.tags.get("subs-only").equals("1");
-        // If the one of the roomstate types have changed notify the chatfragment
-        if (chatIsR9kmode != newR9k || chatIsSlowmode != newSlow || chatIsSubsonlymode != newSub) {
-            chatIsR9kmode = newR9k;
-            chatIsSlowmode = newSlow;
-            chatIsSubsonlymode = newSub;
+        boolean roomstateChanged = false;
 
+        if( message.tags.get("r9k") != null) {
+            chatIsR9kmode = message.tags.get("r9k").equals("1");
+            roomstateChanged = true;
+        }
+        if( message.tags.get("slow") != null) {
+            chatIsSlowmode = !message.tags.get("slow").equals("0");
+            roomstateChanged = true;
+        }
+        if( message.tags.get("subs-only") != null) {
+            chatIsSubsonlymode = message.tags.get("subs-only").equals("1");
+            roomstateChanged = true;
+        }
+
+        // If the one of the roomstate types have changed notify the chatfragment
+        if (roomstateChanged) {
             onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_ROOMSTATE_CHANGE));
         }
     }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -153,52 +153,36 @@
             android:text="@string/chat_status_connecting"
             android:textColor="?attr/chatStatusBarTextColor" />
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
+            android:orientation="horizontal"
             android:layout_gravity="end">
 
-            <View
-                android:id="@+id/roomstate_anchor"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:layout_centerVertical="true" />
-
             <ImageView
-                android:id="@+id/slowmode_ic"
+                android:id="@+id/subsonly_ic"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:layout_centerVertical="true"
-                android:layout_toStartOf="@id/roomstate_anchor"
-                android:layout_toLeftOf="@id/roomstate_anchor"
                 android:visibility="gone"
-                app:srcCompat="@drawable/ic_roomstate_slowmode"
+                app:srcCompat="@drawable/ic_roomstate_subsonly"
                 app:tint="?attr/chatRoomstateIconColor" />
 
             <ImageView
                 android:id="@+id/r9k_ic"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:layout_centerVertical="true"
-                android:layout_toStartOf="@id/slowmode_ic"
-                android:layout_toLeftOf="@id/slowmode_ic"
                 android:visibility="gone"
                 app:srcCompat="@drawable/ic_roomstate_r9k"
                 app:tint="?attr/chatRoomstateIconColor" />
 
             <ImageView
-                android:id="@+id/subsonly_ic"
+                android:id="@+id/slowmode_ic"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:layout_centerVertical="true"
-                android:layout_toStartOf="@id/r9k_ic"
-                android:layout_toLeftOf="@id/r9k_ic"
                 android:visibility="gone"
-                app:srcCompat="@drawable/ic_roomstate_subsonly"
+                app:srcCompat="@drawable/ic_roomstate_slowmode"
                 app:tint="?attr/chatRoomstateIconColor" />
-        </RelativeLayout>
+        </LinearLayout>
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -158,13 +158,21 @@
             android:layout_height="match_parent"
             android:layout_gravity="end">
 
+            <View
+                android:id="@+id/roomstate_anchor"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true" />
+
             <ImageView
                 android:id="@+id/slowmode_ic"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@id/roomstate_anchor"
+                android:layout_toLeftOf="@id/roomstate_anchor"
                 android:visibility="gone"
                 app:srcCompat="@drawable/ic_roomstate_slowmode"
                 app:tint="?attr/chatRoomstateIconColor" />


### PR DESCRIPTION
Only changed roomstate will be contained in the `ROOMSTATE` message when the state is changed while already connected to chat. This causes a `NullPointerException` in `handleRoomstate()` resulting in a crash.

This fix checks if the three supported roomstates exist in the message first, before reading their value. This also properly ignores "unsupported" roomstates like `emote-only`.

I also found that if only `r9k` and `subs-only` was enabled, the chat stausbar would only show the r9k-icon. That's why I added the anchor element. I don't know if this is the right way to do it, but it fixed the issue.
