### PR TITLE
Fix font size being to large in settings

### DIFF
--- a/app/src/main/res/layout/cell_settings_category.xml
+++ b/app/src/main/res/layout/cell_settings_category.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="72dp"
+    android:layout_height="72sp"
     android:background="?selectableItemBackground"
     android:clickable="true"
     android:focusable="true">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -73,7 +73,7 @@
     <!-- Text sizes -->
     <dimen name="font_title_size">20sp</dimen>
     <dimen name="font_activity_icon_size">20sp</dimen>
-    <dimen name="font_settings_size">18sp</dimen>
+    <dimen name="font_settings_size">16sp</dimen>
     <dimen name="font_navigation_drawer_size">14sp</dimen>
     <dimen name="font_navigation_drawer_title">18sp</dimen>
     <dimen name="font_sub_settings_size">14sp</dimen>
@@ -124,7 +124,8 @@
     <!-- Settings Activity -->
     <dimen name="settings_divider_height">1dp</dimen>
     <dimen name="settings_item_height">72dp</dimen>
-    <dimen name="settings_small_item_height">72dp</dimen>
+    <!-- We want to use sp here because of accessibility settings -->
+    <dimen name="settings_small_item_height">76sp</dimen>
     <dimen name="settings_text_left_margin">16dp</dimen>
     <dimen name="settings_text_right_margin">16dp</dimen>
     <dimen name="settings_theme_picket_color_size">23dp</dimen>


### PR DESCRIPTION
# Issue
The issue is that a user can set their phone text size to normal, big, etc. This is breaking the settings when set to the biggest value. 

# Fix 
- Make the title of settings items a little bit smaller (-2dp)
- Change the height of the settings from dp to sp

# Images
### Smallest
![WhatsApp Image 2021-12-13 at 18 51 23](https://user-images.githubusercontent.com/34883496/145863233-37efd171-da04-4825-9d01-f550f3db72bd.jpeg)
![WhatsApp Image 2021-12-13 at 18 51 23 (1)](https://user-images.githubusercontent.com/34883496/145863235-8c6a6c3f-534a-44d4-9ae2-4ff790a9c293.jpeg)

### Default
![WhatsApp Image 2021-12-13 at 18 51 24](https://user-images.githubusercontent.com/34883496/145863304-3a295796-47c9-4c87-824c-d5aa0e05ffb6.jpeg)
![WhatsApp Image 2021-12-13 at 18 51 24 (1)](https://user-images.githubusercontent.com/34883496/145863307-977b12c0-9eb2-4c88-be46-eae20166a1ee.jpeg)

### Bigest
![WhatsApp Image 2021-12-13 at 18 51 23 (2)](https://user-images.githubusercontent.com/34883496/145863282-f8435998-2b5e-4c71-a10e-b5fba7d74e03.jpeg)
![WhatsApp Image 2021-12-13 at 18 51 23 (3)](https://user-images.githubusercontent.com/34883496/145863286-1510a7fe-c4a5-42c1-916c-559a753de27f.jpeg)

