### PR TITLE
Fix instant crash, because of Recent Emotes

### DIFF
--- a/app/src/main/java/com/perflyst/twire/model/Emote.java
+++ b/app/src/main/java/com/perflyst/twire/model/Emote.java
@@ -2,9 +2,8 @@ package com.perflyst.twire.model;
 
 import androidx.annotation.NonNull;
 
-import com.google.common.base.Function;
-
 import java.io.Serializable;
+import java.text.MessageFormat;
 import java.util.HashMap;
 
 /**
@@ -13,11 +12,11 @@ import java.util.HashMap;
 public class Emote implements Comparable<Emote>, Serializable {
     private final String emoteKeyword;
     private final boolean isTextEmote;
-    private Function<String, String> urlTemplate;
+    private String urlTemplate;
     private HashMap<Integer, String> urlMap;
     private boolean isSubscriberEmote, isCustomChannelEmote;
 
-    public Emote(String emoteKeyword, Function<String, String> urlTemplate) {
+    public Emote(String emoteKeyword, String urlTemplate) {
         this.emoteKeyword = emoteKeyword;
         this.urlTemplate = urlTemplate;
         this.isTextEmote = false;
@@ -35,12 +34,11 @@ public class Emote implements Comparable<Emote>, Serializable {
     }
 
     public static Emote Twitch(String keyword, String id) {
-        // TODO: Check the theme and use the correct URL.
-        return new Emote(keyword, size -> "https://static-cdn.jtvnw.net/emoticons/v2/" + id + "/default/light/" + size + ".0");
+        return new Emote(keyword, "https://static-cdn.jtvnw.net/emoticons/v1/" + id + "/{0}.0");
     }
 
     public static Emote BTTV(String keyword, String id) {
-        return new Emote(keyword, size -> "https://cdn.betterttv.net/emote/" + id + "/" + size + "x");
+        return new Emote(keyword, "https://cdn.betterttv.net/emote/" + id + "/{0}x");
     }
 
     public static Emote FFZ(String keyword, HashMap<Integer, String> urlMap) {
@@ -48,8 +46,9 @@ public class Emote implements Comparable<Emote>, Serializable {
     }
 
     public static Emote SevenTV(String keyword, String id) {
-        return new Emote(keyword, size -> "https://cdn.7tv.app/emote/" + id + "/" + size + "x");
+        return new Emote(keyword, "https://cdn.7tv.app/emote/" + id + "/{0}x");
     }
+
 
     public boolean isCustomChannelEmote() {
         return isCustomChannelEmote;
@@ -78,7 +77,7 @@ public class Emote implements Comparable<Emote>, Serializable {
             return null;
         }
 
-        return urlTemplate == null ? null : urlTemplate.apply(String.valueOf(size));
+        return urlTemplate == null ? null : MessageFormat.format(urlTemplate, size);
     }
 
     public int getBestAvailableSize(int size) {

--- a/app/src/main/java/com/perflyst/twire/service/Settings.java
+++ b/app/src/main/java/com/perflyst/twire/service/Settings.java
@@ -20,8 +20,7 @@ import java.util.ArrayList;
  * Created by SebastianRask on 29-04-2015.
  */
 public class Settings {
-    private static final Type MAP_TYPE = new TypeToken<ArrayList<Emote>>() {
-    }.getType();
+    private static final Type MAP_TYPE = new TypeToken<ArrayList<Emote>>(){}.getType();
     private final String GENERAL_TWITCH_ACCESS_TOKEN_KEY = "genTwitchAccessToken";
     private final String GENERAL_TWITCH_NAME_KEY = "genTwitchName";
     private final String GENERAL_TWITCH_DISPLAY_NAME_KEY = "genTwitchDisplayName";
@@ -155,11 +154,6 @@ public class Settings {
         editor.commit();
     }
 
-    public ArrayList<Emote> getRecentEmotes() {
-        SharedPreferences preferences = getPreferences();
-        return new Gson().fromJson(preferences.getString(this.CHAT_RECENT_EMOTES, ""), MAP_TYPE);
-    }
-
     /**
      * Emotes - list of recent emotes
      */
@@ -170,14 +164,19 @@ public class Settings {
         editor.commit();
     }
 
-    public String getAppearanceGameSize() {
+    public ArrayList<Emote> getRecentEmotes() {
         SharedPreferences preferences = getPreferences();
-        return preferences.getString(this.APPEARANCE_GAME_SIZE, context.getString(R.string.card_size_large));
+        return new Gson().fromJson(preferences.getString(this.CHAT_RECENT_EMOTES, ""), MAP_TYPE);
     }
 
     /**
      * Appearance - The size of the Game Card.
      */
+
+    public String getAppearanceGameSize() {
+        SharedPreferences preferences = getPreferences();
+        return preferences.getString(this.APPEARANCE_GAME_SIZE, context.getString(R.string.card_size_large));
+    }
 
     public void setAppearanceGameSize(String sizeName) {
         SharedPreferences.Editor editor = getEditor();


### PR DESCRIPTION
Steps to Reproduce:
1. Log in
2. Join a Channel and send a Message with Emotes
3. Click Back
4. Close the App
5. Open the App
6. Try to watch a Stream
7. Crash

- The Issue is there since: 763188f09739700c8c00c066ee5a2ca2ae8ae22d
- Seems to be the same problem as #86

# Fix 
There are 2 Ways of fixing it:
1. Just revert the Changes to the Emote class in 763188f09739700c8c00c066ee5a2ca2ae8ae22d
2. Do some gson magic which I don´t understand

In #86 it got fixed using Way 1.