### PR TITLE
Improve chat performance

### DIFF
--- a/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
+++ b/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
@@ -5,12 +5,11 @@ package com.perflyst.twire.chat;
  */
 
 import android.content.Context;
-import android.os.AsyncTask;
-import android.os.Handler;
 import android.os.SystemClock;
 import android.util.Log;
 import android.util.SparseArray;
 
+import com.perflyst.twire.TwireApplication;
 import com.perflyst.twire.model.Badge;
 import com.perflyst.twire.model.ChatEmote;
 import com.perflyst.twire.model.ChatMessage;
@@ -33,15 +32,18 @@ import java.net.Socket;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Random;
 
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
-public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Void> {
-    public static final int VOD_LOADING = -1;
+public class ChatManager implements Runnable {
+    public static ChatManager instance = null;
+
     public static final List<Badge> ffzBadges = new ArrayList<>();
     private static double currentProgress;
     private static String cursor = "";
@@ -63,8 +65,10 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
     private int twitchChatPortsecure = 6697;
     private int twitchChatPort;
 
+    private final Object vodLock = new Object();
+    private double nextCommentOffset = 0;
+
     private BufferedWriter writer;
-    private Handler callbackHandler;
     private boolean isStopping;
     // Data about the user and how to display his/hers message
     private String userDisplayName;
@@ -76,6 +80,8 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
     private boolean chatIsSubsonlymode;
 
     public ChatManager(Context aContext, UserInfo aChannel, String aVodId, ChatCallback aCallback) {
+        instance = this;
+
         Settings appSettings = new Settings(aContext);
         mEmoteManager = new ChatEmoteManager(aChannel, appSettings);
 
@@ -106,13 +112,20 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
             twitchChatPort = twitchChatPortunsecure;
         }
         Log.d(LOG_TAG, "Use SSL Chat Server: " + appSettings.getChatEnableSSL());
-
-        executeOnExecutor(THREAD_POOL_EXECUTOR);
     }
 
     public static void updateVodProgress(int aCurrentProgress, boolean aSeek) {
         currentProgress = aCurrentProgress / 1000f;
         seek |= aSeek;
+
+        if (instance == null) return;
+
+        // Only notify the thread when there's work to do.
+        if (!aSeek && currentProgress < instance.nextCommentOffset) return;
+
+        synchronized (instance.vodLock) {
+            instance.vodLock.notify();
+        }
     }
 
     public static void setPreviousProgress() {
@@ -121,13 +134,7 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
     }
 
     @Override
-    protected void onPreExecute() {
-        super.onPreExecute();
-        callbackHandler = new Handler();
-    }
-
-    @Override
-    protected Void doInBackground(Void... params) {
+    public void run() {
         Log.d(LOG_TAG, "Trying to start chat " + channel.getLogin() + " for user " + user);
         mEmoteManager.loadCustomEmotes(() -> onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_CUSTOM_EMOTES_FETCHED)));
 
@@ -140,16 +147,12 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
         } else {
             processVodChat();
         }
-
-        return null;
     }
 
-    @Override
     protected void onProgressUpdate(ProgressUpdate... values) {
-        super.onProgressUpdate(values);
         final ProgressUpdate update = values[0];
         final ProgressUpdate.UpdateType type = update.getUpdateType();
-        callbackHandler.post(() -> {
+        TwireApplication.uiThreadPoster.post(() -> {
             switch (type) {
                 case ON_MESSAGE:
                     callback.onMessage(update.getMessage());
@@ -178,11 +181,6 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
         });
     }
 
-    @Override
-    protected void onPostExecute(Void aVoid) {
-        super.onPostExecute(aVoid);
-        Log.d(LOG_TAG, "Finished executing - Ending chat");
-    }
 
     /**
      * Connect to twitch with the users twitch name and oauth key.
@@ -255,116 +253,122 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
         }
     }
 
+    private static class VODComment {
+        public final double contentOffset;
+        public final JSONObject data;
+
+        private VODComment(double contentOffset, JSONObject data) {
+            this.contentOffset = contentOffset;
+            this.data = data;
+        }
+    }
+
     private void processVodChat() {
         try {
-            onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_CONNECTED));
+            synchronized (vodLock) {
+                onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_CONNECTED));
 
-            List<JSONObject> downloadedComments = new ArrayList<>();
-            boolean reconnecting = false;
-            boolean justSeeked = false;
-            while (!isStopping) {
-                if (currentProgress == VOD_LOADING) {
-                    continue;
-                }
+                // Make sure that current progress has been set.
+                vodLock.wait();
 
-                if (seek) {
-                    seek = false;
-                    cursor = "";
-                    downloadedComments.clear();
-                    previousProgress = 0;
-                    justSeeked = true;
-                }
-
-                if (downloadedComments.isEmpty()) {
-                    String result = Service.urlToJSONString("https://api.twitch.tv/v5/videos/" + vodId + "/comments?cursor=" + cursor + "&content_offset_seconds=" + currentProgress, false);
-
-                    if (result.isEmpty()) {
-                        reconnecting = true;
-                        onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_RECONNECTING));
-                        SystemClock.sleep(2500);
-                        continue;
-                    } else if (reconnecting) {
-                        reconnecting = false;
-                        onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_CONNECTED));
+                Queue<VODComment> downloadedComments = new LinkedList<>();
+                boolean reconnecting = false;
+                boolean justSeeked = false;
+                while (!isStopping) {
+                    if (seek) {
+                        seek = false;
+                        cursor = "";
+                        downloadedComments.clear();
+                        previousProgress = 0;
+                        justSeeked = true;
                     }
 
-                    JSONObject commentsObject = new JSONObject(result);
-                    JSONArray comments = commentsObject.getJSONArray("comments");
+                    VODComment comment = downloadedComments.peek();
+                    if (comment == null) {
+                        String result = Service.urlToJSONString("https://api.twitch.tv/v5/videos/" + vodId + "/comments?cursor=" + cursor + "&content_offset_seconds=" + currentProgress, false);
 
-                    for (int i = 0; i < comments.length(); i++) {
-                        JSONObject comment = comments.getJSONObject(i);
-                        double contentOffset = comment.getDouble("content_offset_seconds");
-                        // Don't show previous comments and don't show comments that came before the current progress unless we just seeked.
-                        if (contentOffset < previousProgress || contentOffset < currentProgress && !justSeeked)
+                        if (result.isEmpty()) {
+                            reconnecting = true;
+                            onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_RECONNECTING));
+                            SystemClock.sleep(2500);
                             continue;
-
-                        downloadedComments.add(comment);
-                    }
-
-                    justSeeked = false;
-
-                    // Assumption: If the VOD has no comments and no previous or next comments, there are no comments on the VOD.
-                    if (comments.length() == 0 && !commentsObject.has("_next") && !commentsObject.has("_prev")) {
-                        break;
-                    }
-
-                    if (commentsObject.has("_next"))
-                        cursor = commentsObject.getString("_next");
-                }
-
-                if (seek) {
-                    seek = false;
-                    cursor = "";
-                    downloadedComments.clear();
-                    previousProgress = 0;
-                    justSeeked = true;
-                    continue;
-                }
-
-                for (int i = 0; i < downloadedComments.size(); i++) {
-                    JSONObject comment = downloadedComments.get(i);
-                    if (currentProgress >= comment.getDouble("content_offset_seconds")) {
-                        JSONObject commenter = comment.getJSONObject("commenter");
-                        JSONObject message = comment.getJSONObject("message");
-
-                        Map<String, String> badges = new HashMap<>();
-                        if (message.has("user_badges")) {
-                            JSONArray userBadgesArray = message.getJSONArray("user_badges");
-                            for (int j = 0; j < userBadgesArray.length(); j++) {
-                                JSONObject userBadge = userBadgesArray.getJSONObject(j);
-                                badges.put(userBadge.getString("_id"), userBadge.getString("version"));
-                            }
+                        } else if (reconnecting) {
+                            reconnecting = false;
+                            onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_CONNECTED));
                         }
 
-                        String color = message.has("user_color") ? message.getString("user_color") : null;
-                        String displayName = commenter.getString("display_name");
-                        String body = message.getString("body");
+                        JSONObject commentsObject = new JSONObject(result);
+                        JSONArray comments = commentsObject.getJSONArray("comments");
 
-                        List<ChatEmote> emotes = new ArrayList<>();
-                        if (message.has("emoticons")) {
-                            JSONArray emoticonsArray = message.getJSONArray("emoticons");
-                            for (int j = 0; j < emoticonsArray.length(); j++) {
-                                JSONObject emoticon = emoticonsArray.getJSONObject(j);
-                                int begin = emoticon.getInt("begin");
-                                int end = emoticon.getInt("end") + 1;
-                                // In some cases, Twitch gets the indexes of emotes wrong so we have to ignore any emotes that go over the length of the message.
-                                if (end > body.length())
-                                    continue;
+                        for (int i = 0; i < comments.length(); i++) {
+                            JSONObject commentJSON = comments.getJSONObject(i);
+                            double contentOffset = commentJSON.getDouble("content_offset_seconds");
+                            // Don't show previous comments and don't show comments that came before the current progress unless we just seeked.
+                            if (contentOffset < previousProgress || contentOffset < currentProgress && !justSeeked)
+                                continue;
 
-                                String keyword = body.substring(begin, end);
-                                emotes.add(new ChatEmote(Emote.Twitch(keyword, emoticon.getString("_id")), new int[]{begin}));
-                            }
+                            downloadedComments.add(new VODComment(contentOffset, commentJSON));
                         }
-                        emotes.addAll(mEmoteManager.findCustomEmotes(body));
 
-                        //Pattern.compile(Pattern.quote(userDisplayName), Pattern.CASE_INSENSITIVE).matcher(message).find();
+                        justSeeked = false;
 
-                        ChatMessage chatMessage = new ChatMessage(body, displayName, color, getBadges(badges), emotes, false);
-                        publishProgress(new ProgressUpdate(ProgressUpdate.UpdateType.ON_MESSAGE, chatMessage));
+                        // Assumption: If the VOD has no comments and no previous or next comments, there are no comments on the VOD.
+                        if (comments.length() == 0 && !commentsObject.has("_next") && !commentsObject.has("_prev")) {
+                            break;
+                        }
 
-                        downloadedComments.remove(i);
-                        i--;
+                        if (commentsObject.has("_next"))
+                            cursor = commentsObject.getString("_next");
+
+                        comment = downloadedComments.peek();
                     }
+
+                    if (seek || comment == null) {
+                        continue;
+                    }
+
+                    nextCommentOffset = comment.contentOffset;
+                    if (currentProgress < nextCommentOffset) vodLock.wait();
+
+                    JSONObject commenter = comment.data.getJSONObject("commenter");
+                    JSONObject message = comment.data.getJSONObject("message");
+
+                    Map<String, String> badges = new HashMap<>();
+                    if (message.has("user_badges")) {
+                        JSONArray userBadgesArray = message.getJSONArray("user_badges");
+                        for (int j = 0; j < userBadgesArray.length(); j++) {
+                            JSONObject userBadge = userBadgesArray.getJSONObject(j);
+                            badges.put(userBadge.getString("_id"), userBadge.getString("version"));
+                        }
+                    }
+
+                    String color = message.has("user_color") ? message.getString("user_color") : null;
+                    String displayName = commenter.getString("display_name");
+                    String body = message.getString("body");
+
+                    List<ChatEmote> emotes = new ArrayList<>();
+                    if (message.has("emoticons")) {
+                        JSONArray emoticonsArray = message.getJSONArray("emoticons");
+                        for (int j = 0; j < emoticonsArray.length(); j++) {
+                            JSONObject emoticon = emoticonsArray.getJSONObject(j);
+                            int begin = emoticon.getInt("begin");
+                            int end = emoticon.getInt("end") + 1;
+                            // In some cases, Twitch gets the indexes of emotes wrong so we have to ignore any emotes that go over the length of the message.
+                            if (end > body.length())
+                                continue;
+
+                            String keyword = body.substring(begin, end);
+                            emotes.add(new ChatEmote(Emote.Twitch(keyword, emoticon.getString("_id")), new int[]{begin}));
+                        }
+                    }
+                    emotes.addAll(mEmoteManager.findCustomEmotes(body));
+
+                    //Pattern.compile(Pattern.quote(userDisplayName), Pattern.CASE_INSENSITIVE).matcher(message).find();
+
+                    ChatMessage chatMessage = new ChatMessage(body, displayName, color, getBadges(badges), emotes, false);
+                    onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_MESSAGE, chatMessage));
+
+                    downloadedComments.poll();
                 }
             }
         } catch (Exception e) {
@@ -499,7 +503,7 @@ public class ChatManager extends AsyncTask<Void, ChatManager.ProgressUpdate, Voi
             chatMessage.setHighlight(true);
         }
 
-        publishProgress(new ProgressUpdate(ProgressUpdate.UpdateType.ON_MESSAGE, chatMessage));
+        onProgressUpdate(new ProgressUpdate(ProgressUpdate.UpdateType.ON_MESSAGE, chatMessage));
     }
 
     /**

--- a/app/src/main/java/com/perflyst/twire/fragments/ChatFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/ChatFragment.java
@@ -47,6 +47,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.tabs.TabLayout;
 import com.perflyst.twire.R;
+import com.perflyst.twire.TwireApplication;
 import com.perflyst.twire.activities.stream.LiveStreamActivity;
 import com.perflyst.twire.adapters.ChatAdapter;
 import com.perflyst.twire.chat.ChatManager;
@@ -292,6 +293,8 @@ public class ChatFragment extends Fragment implements EmoteKeyboardDelegate, Cha
                 }
             }
         });
+
+        TwireApplication.backgroundPoster.post(chatManager);
 
         if (supportedTextEmotes == null) {
             supportedTextEmotes = new ArrayList<>();

--- a/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
+++ b/app/src/main/java/com/perflyst/twire/fragments/StreamFragment.java
@@ -456,8 +456,6 @@ public class StreamFragment extends Fragment implements Player.Listener {
 
             mCurrentProgressView.setOnClickListener(v -> showSeekDialog());
 
-            ChatManager.updateVodProgress(ChatManager.VOD_LOADING, true);
-
             TextView maxProgress = mRootView.findViewById(R.id.maxProgress);
             maxProgress.setText(Service.calculateTwitchVideoLength(vodLength));
 
@@ -765,7 +763,7 @@ public class StreamFragment extends Fragment implements Player.Listener {
             releasePlayer();
         }
 
-        ChatManager.setPreviousProgress();
+        ChatManager.instance.setPreviousProgress();
     }
 
     @Override

--- a/app/src/main/java/com/perflyst/twire/misc/GlideImageSpan.java
+++ b/app/src/main/java/com/perflyst/twire/misc/GlideImageSpan.java
@@ -42,7 +42,6 @@ public class GlideImageSpan extends VerticalImageSpan implements Drawable.Callba
         super(new BlankDrawable());
 
         this.textView = textView;
-        this.textView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         final GlideImageSpan instance = this;
 
         int scaledAssumedSize = Math.round(assumedSize / scale);
@@ -62,7 +61,6 @@ public class GlideImageSpan extends VerticalImageSpan implements Drawable.Callba
                     @Override
                     public void onLoadStarted(Drawable resource) {
                         mDrawable = resource;
-                        textView.invalidate();
                     }
 
                     @Override
@@ -73,22 +71,21 @@ public class GlideImageSpan extends VerticalImageSpan implements Drawable.Callba
                             animatable = (Animatable) resource;
                             resource.setCallback(instance);
 
+                            instance.textView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+
                             animatable.start();
                         }
 
                         mDrawable = resource;
-                        if (resource.getIntrinsicWidth() != assumedSize) {
-                            textView.setText(builder);
-                        } else {
-                            textView.invalidate();
-                        }
+
+                        textView.setText(builder);
                     }
 
 
                     @Override
                     public void onLoadFailed(Drawable resource) {
                         mDrawable = resource;
-                        textView.invalidate();
+                        textView.setText(builder);
                     }
 
                     @Override
@@ -98,7 +95,7 @@ public class GlideImageSpan extends VerticalImageSpan implements Drawable.Callba
                         }
 
                         mDrawable = placeholder;
-                        textView.invalidate();
+                        textView.setText(builder);
                     }
                 });
     }
@@ -132,22 +129,4 @@ public class GlideImageSpan extends VerticalImageSpan implements Drawable.Callba
 
         return drawable;
     }
-
-/*
-    @Override
-    public void chooseHeight(CharSequence text, int start, int end, int spanstartv, int lineHeight, Paint.FontMetricsInt fm) {
-        if (end == ((Spanned) text).getSpanEnd(this)) {
-            int ht = getDrawable().getIntrinsicHeight();
-
-            int need = ht - (lineHeight + fm.descent - fm.ascent - spanstartv);
-            if (need > 0) {
-                fm.descent += need;
-            }
-
-            need = ht - (lineHeight + fm.bottom - fm.top - spanstartv);
-            if (need > 0) {
-                fm.bottom += need;
-            }
-        }
-    }*/
 }

--- a/app/src/main/java/com/perflyst/twire/misc/VerticalImageSpan.java
+++ b/app/src/main/java/com/perflyst/twire/misc/VerticalImageSpan.java
@@ -13,6 +13,8 @@ public class VerticalImageSpan extends ImageSpan {
         super(drawable);
     }
 
+    private int yOffset;
+
     @Override
     public int getSize(@NonNull Paint paint, CharSequence text,
                        int start, int end,
@@ -21,11 +23,11 @@ public class VerticalImageSpan extends ImageSpan {
         Rect rect = d.getBounds();
 
         if (fm != null) {
-            Paint.FontMetricsInt pfm = paint.getFontMetricsInt();
-
-            int ascent = pfm.ascent;
-            int middle = ascent + (pfm.descent - ascent) / 2;
+            int ascent = fm.ascent;
+            int middle = ascent + (fm.descent - ascent) / 2;
             int halfHeight = rect.height() / 2;
+
+            yOffset = middle - halfHeight;
 
             fm.ascent = middle - halfHeight;
             fm.top = fm.ascent;
@@ -41,14 +43,8 @@ public class VerticalImageSpan extends ImageSpan {
                      int start, int end, float x,
                      int top, int y, int bottom, @NonNull Paint paint) {
         Drawable drawable = getDrawable();
-        Rect bounds = drawable.getBounds();
         canvas.save();
-
-        Paint.FontMetricsInt fontMetricsInt = paint.getFontMetricsInt();
-        int descent = fontMetricsInt.descent;
-        int transY = y + descent - (descent - fontMetricsInt.ascent) / 2;
-        canvas.translate(x, (float) (transY - bounds.height() / 2));
-
+        canvas.translate(x, y + yOffset);
         drawable.draw(canvas);
         canvas.restore();
     }

--- a/app/src/main/java/com/perflyst/twire/model/Badge.java
+++ b/app/src/main/java/com/perflyst/twire/model/Badge.java
@@ -2,21 +2,17 @@ package com.perflyst.twire.model;
 
 import android.util.SparseArray;
 
-import java.util.List;
-
 public class Badge {
     public final String name;
     public final SparseArray<String> urls;
     public final String color;
     public final String replaces;
-    public final List<String> users;
 
-    public Badge(String name, SparseArray<String> urls, String color, String replaces, List<String> users) {
+    public Badge(String name, SparseArray<String> urls, String color, String replaces) {
         this.name = name;
         this.urls = urls;
         this.color = color;
         this.replaces = replaces;
-        this.users = users;
     }
 
     public Badge(String name, SparseArray<String> urls) {
@@ -24,7 +20,6 @@ public class Badge {
         this.urls = urls;
         color = null;
         replaces = null;
-        users = null;
     }
 
     public String getUrl(int size) {

--- a/app/src/main/java/com/perflyst/twire/model/ChatMessage.java
+++ b/app/src/main/java/com/perflyst/twire/model/ChatMessage.java
@@ -24,18 +24,16 @@ public class ChatMessage {
         this.highlight = highlight;
 
         // Load any special FFZ badges the user has
-        for (Badge badge : ChatManager.ffzBadges) {
-            if (badge.users.contains(name.toLowerCase())) {
-                if (badge.replaces != null) {
-                    for (int i = 0; i < badges.size(); i++) {
-                        if (badges.get(i).name.equals(badge.replaces)) {
-                            badges.set(i, badge);
-                            break;
-                        }
+        for (Badge badge : ChatManager.ffzBadgeMap.get(name.toLowerCase())) {
+            if (badge.replaces != null) {
+                for (int i = 0; i < badges.size(); i++) {
+                    if (badges.get(i).name.equals(badge.replaces)) {
+                        badges.set(i, badge);
+                        break;
                     }
-                } else {
-                    badges.add(badge);
                 }
+            } else {
+                badges.add(badge);
             }
         }
     }

--- a/app/src/main/java/com/perflyst/twire/model/IRCMessage.java
+++ b/app/src/main/java/com/perflyst/twire/model/IRCMessage.java
@@ -9,8 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class IRCMessage {
-    static Pattern ircPattern = Pattern.compile("(?:@(.+) )?:.+ ([A-Z]+) #\\S*(?: :(.+))?"),
-            tagPattern = Pattern.compile("([^=]+)=?(.+)?");
+    static Pattern ircPattern = Pattern.compile("(?:@(.+) )?:.+ ([A-Z]+) #\\S*(?: :(.+))?");
 
     public Map<String, String> tags;
     public String command;
@@ -37,27 +36,25 @@ public class IRCMessage {
         if (tagString == null)
             return Collections.emptyMap();
 
-        Map<String, String> replacements = new HashMap<>();
-        replacements.put("\\:", ";");
-        replacements.put("\\s", " ");
-        replacements.put("\\\\", "\\");
-        replacements.put("\\r", "\r");
-        replacements.put("\\n", "\n");
-
         Map<String, String> tags = new HashMap<>();
         for (String tag : tagString.split(";")) {
-            Matcher tagMatcher = tagPattern.matcher(tag);
-            if (tagMatcher.find()) {
-                String value = tagMatcher.group(2);
-                if (value == null)
-                    continue;
-
-                for (Map.Entry<String, String> entry : replacements.entrySet()) {
-                    value = value.replace(entry.getKey(), entry.getValue());
-                }
-
-                tags.put(tagMatcher.group(1), value);
+            int index = tag.indexOf('=');
+            if (index == tag.length() - 1 || index == -1) {
+                continue;
             }
+
+            String value = tag.substring(index + 1);
+
+            if (value.contains("\\")) {
+                value = value
+                        .replace("\\:", ";")
+                        .replace("\\s", " ")
+                        .replace("\\\\", "\\")
+                        .replace("\\r", "\r")
+                        .replace("\\n", "\n");
+            }
+
+            tags.put(tag.substring(0, index), value);
         }
 
         return tags;


### PR DESCRIPTION
This PR is going to be focused on improving the performance of the chat. This closes #197.

There's some smaller changes, but the two big improvements come from using hardware rendering for chat messages and removing an idle loop from the VOD chat code. Using hardware rendering moves work off the CPU and to the GPU. Removing the idle loop means that the CPU can sleep when there's no work to do.