### PR TITLE
Fix 7TV emotes not animating

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 
     //https://github.com/bumptech/glide/releases
     def glideVersion = "4.12.0"
+    implementation "com.github.zjupure:webpdecoder:2.0.${glideVersion}"
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     annotationProcessor "com.github.bumptech.glide:compiler:$glideVersion"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,3 +13,8 @@
 
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
+
+#  GlideWebpDecoder uses native code to decode webp, keep the jni interface.
+-keep public class com.bumptech.glide.integration.webp.WebpImage { *; }
+-keep public class com.bumptech.glide.integration.webp.WebpFrame { *; }
+-keep public class com.bumptech.glide.integration.webp.WebpBitmapFactory { *; }


### PR DESCRIPTION
Most all of the 7TV emotes are animated WEBP images. Glide doesn't support this and thus almost all emotes are not animated.
I added the https://github.com/zjupure/GlideWebpDecoder library to make it work.