### PR TITLE
Navigation back event fixes for landscape orientation

### DIFF
--- a/app/src/main/java/com/perflyst/twire/activities/settings/SettingsTwitchChatActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/settings/SettingsTwitchChatActivity.java
@@ -163,7 +163,7 @@ public class SettingsTwitchChatActivity extends ThemeActivity {
                     updateSummaries();
                 },
                 landscapeWidth,
-                25,
+                10,
                 60,
                 getString(R.string.chat_landscape_width_dialog)
         ).show();

--- a/app/src/main/java/com/perflyst/twire/activities/stream/StreamActivity.java
+++ b/app/src/main/java/com/perflyst/twire/activities/stream/StreamActivity.java
@@ -46,6 +46,7 @@ public abstract class StreamActivity extends ThemeActivity implements StreamFrag
     private Settings settings;
     private boolean mBackstackLost;
     private boolean onStopCalled;
+    private int initialOrientation;
 
     protected abstract int getLayoutResource();
 
@@ -62,6 +63,8 @@ public abstract class StreamActivity extends ThemeActivity implements StreamFrag
 
         getWindow().setNavigationBarColor(ContextCompat.getColor(this, R.color.black));
         getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.black));
+
+        initialOrientation = getResources().getConfiguration().orientation;
 
         if (savedInstanceState == null) {
             FragmentManager fm = getSupportFragmentManager();
@@ -111,7 +114,9 @@ public abstract class StreamActivity extends ThemeActivity implements StreamFrag
 
         // Eww >(
         if (mStreamFragment != null) {
-            if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            boolean isCurrentlyLandscape = getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+            boolean wasInitiallyLandscape = initialOrientation == Configuration.ORIENTATION_LANDSCAPE;
+            if (isCurrentlyLandscape && !wasInitiallyLandscape) {
                 mStreamFragment.toggleFullscreen();
             } else if (mStreamFragment.chatOnlyViewVisible) {
                 this.finish();


### PR DESCRIPTION
Closes #393.

When a live stream activity is created in landscape mode, I would expect that a back navigation would cause the live stream itself to be closed and not to be put in portrait mode (as it did in v2.10.3). In v2.10.4 as part of the [StreamFragment refactor](https://github.com/twireapp/Twire/compare/v2.10.3...twireapp:Twire:v2.10.4#diff-9b21c9fa2fb704b8990760ed90c86e1d868bb74e250e012dbff58858aa1204ee), the [isFullscreen](https://github.com/twireapp/Twire/compare/v2.10.3...twireapp:Twire:v2.10.4#diff-9b21c9fa2fb704b8990760ed90c86e1d868bb74e250e012dbff58858aa1204eeL131) boolean was previously used to determine whether to toggle fullscreen or not [when a back navigation event occurred](https://github.com/twireapp/Twire/compare/v2.10.3...twireapp:Twire:v2.10.4#diff-628667984cd6400d805a39adbb5f74c067f1670a02949148d6ad1dcb59a8af01L118). In version v2.10.3 the isFullscreen flag would only ever change if the user was to manually switch to fullscreen. As part of the v2.10.4 refactor, this now relies on [dynamically evaluating the current orientation](https://github.com/twireapp/Twire/compare/v2.10.3...twireapp:Twire:v2.10.4#diff-628667984cd6400d805a39adbb5f74c067f1670a02949148d6ad1dcb59a8af01R118) without considering the users initial orientation. I've introduced [StreamFragment#getInitialOrientation](https://github.com/twireapp/Twire/compare/master...tim-crisp:Twire:tablet-fixes?expand=1#diff-9b21c9fa2fb704b8990760ed90c86e1d868bb74e250e012dbff58858aa1204eeR1147-R1149) which exposes the initial orientation at the point of which a [StreamFragment was created](https://github.com/twireapp/Twire/compare/master...tim-crisp:Twire:tablet-fixes?expand=1#diff-9b21c9fa2fb704b8990760ed90c86e1d868bb74e250e012dbff58858aa1204eeR266). This is then used in [StreamActivity#onBackPressed](https://github.com/twireapp/Twire/compare/master...tim-crisp:Twire:tablet-fixes?expand=1#diff-628667984cd6400d805a39adbb5f74c067f1670a02949148d6ad1dcb59a8af01R118-R120) to determine whether we should be toggling full screen or not given the current orientation is landscape.
**Visual Representation:**
![image](https://user-images.githubusercontent.com/5111551/198845268-ef3c3cba-fb49-4067-a4d2-6cae61c760e7.png)


I've also [reduced the minimum chat size threshold](https://github.com/twireapp/Twire/compare/master...tim-crisp:Twire:tablet-fixes?expand=1#diff-4f5537c9e98b5b681f06e1940056acc6623f85adbadfa3bb17bd5e554647bd0bR166) to better cater for larger tablets.

FYI: I don't often write OOP and have only ever worked on personal android apps.