### PR TITLE
Add support for a themed app icon on Android 13+

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/primary" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
This PR adds a monochrome icon to allow the app icon to be themed on the home screen.

For the themed app icon to be displayed, the user must:

- Be on Android 13 or newer
- Enable **Themed icons** in system settings
- Use a launcher supporting themed icons

Before:
![Screenshot_20221106-204238](https://user-images.githubusercontent.com/33134232/200229265-d8df3e9a-e4f3-4bc6-b0dd-45873a681580.png)
After:
![Screenshot_20221106-204338](https://user-images.githubusercontent.com/33134232/200229281-8127e44d-d394-4ba1-858b-f271cb9e7288.png)