### PR TITLE
Migrate VOD chat to new API

### DIFF
--- a/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
+++ b/app/src/main/java/com/perflyst/twire/chat/ChatManager.java
@@ -264,6 +264,12 @@ public class ChatManager implements Runnable {
     }
 
     private void processVodChat() {
+        // Very crude disabling of the function, because Twitch changed their API and this makes the app freeze up
+        onUpdate(UpdateType.ON_CONNECTION_FAILED);
+        if(true)
+            return;
+
+
         try {
             synchronized (vodLock) {
                 onUpdate(UpdateType.ON_CONNECTED);


### PR DESCRIPTION
Twitch shutdown their v5 video comments API. 
Now the GQL-API is used to fetch the VOD chat.
I also removed the sleep statements when an error occurs. This makes the UI no longer freeze up in that case. It will still try to reconnect every second due to the progress updating.

Fixes #408 