### PR TITLE
Fix GitHub action ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"
@@ -21,11 +22,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -58,11 +59,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: AVD cache
         uses: actions/cache@v3


### PR DESCRIPTION
This fixes the ci werkflow being broken by using Java 17 instead. (Temurin from Adoptium as AdoptOpenJDK isn't a thing anymore)

Also add ability to manually trigger the workflow